### PR TITLE
fix(ui): 恢复搜索框并清理 main.js 死代码

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,19 @@ squidfunk/mkdocs-material → oi-wiki 深度定制 → Hi-Yincan/mkdocs-material
 纯静态站点,无后端、无数据库。内容为协作维护的原创中文资料,覆盖 AI 产品方法论、LLM 能力与工具、
 提示词工程、Agent 工作流、评测与求职专题等。
 
+### 搜索架构与主题维护(2026-08 定案:不装包、深定制 fork)
+
+- 主题经 `custom_dir` 加载(`theme.name: null`),**不安装** `material` Python 包,故 mkdocs.yml 的
+  `- search:` 解析为 **mkdocs 内置 search 插件**(`config.plugins` 键为 `search`,非 `material/search`)。
+- 兼容契约:主题 `partials/header.html` 的搜索检查用双键
+  `"material/search" in config.plugins or "search" in config.plugins`(子模块已改,勿改回单键)。
+- `hooks/on_env.py` 的 `on_config` 摘除内置插件注入的 `search/main.js`(经典主题死代码,依赖
+  `base_url`,每页抛 ReferenceError)。
+- 主题子模块改动一律**提交后立即推送**子模块远端,防止 gitlink 指向远端不存在的 commit
+  导致 clone/CI/submodule update 失败(2026-08-23 踩过:主题 4 个 commit 未推,整链断裂)。
+- 规模思考:搜索引擎可换(换 mkdocs 插件即可,内容零改动);真正的长期投资在内容结构
+  (锚点稳定、frontmatter/tags、区块目录),不锁定任何搜索方案。
+
 ## 文档结构
 
 `docs/` 按主题分为六个区块 + 求职专题:

--- a/docs/_static/css/extra.css
+++ b/docs/_static/css/extra.css
@@ -1115,15 +1115,3 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
   width: 100%;
   height: 100%;
 }
-
-/* 12.3 图注:左下角等宽小字,呼应站点 11px/等宽 的图注语气 */
-.pm-banner__caption {
-  position: absolute;
-  left: 18px;
-  bottom: 14px;
-  margin: 0;
-  font-family: "JetBrains Mono", "Fira Mono", ui-monospace, monospace;
-  font-size: 11px;
-  letter-spacing: .08em;
-  color: var(--pm-faint);
-}

--- a/hooks/on_env.py
+++ b/hooks/on_env.py
@@ -11,3 +11,13 @@ def _nav_math():
 def on_env(env, config, files, **kwargs):
     env.filters["nav_math"] = _nav_math()
     return env
+
+def on_config(config, **kwargs):
+    # mkdocs 内置 search 插件会把经典主题的搜索 UI(search/main.js)注入每页,
+    # 本仓库用 Material 模板渲染搜索,该脚本是死代码且依赖经典主题的 base_url 全局变量,
+    # 每页加载都会抛 ReferenceError。hook 在插件 on_config 之后执行,这里摘掉它。
+    try:
+        config["extra_javascript"].remove("search/main.js")
+    except ValueError:
+        pass
+    return config


### PR DESCRIPTION
## 内容
- **搜索框恢复**:主题子模块 8ab19ab92 引入官方 `material/search` 插件检查,与本仓库(custom_dir 加载 + 内置 search 插件)不匹配,搜索按钮不再渲染;子模块改为兼容 `search` 键(`20a2b8a4c`),主仓库同步指针。
- **main.js 死代码清理**:内置 search 插件注入的经典主题搜索脚本,每页抛 ReferenceError,已用 on_config hook 摘除。
- **架构决策固化**:CLAUDE.md 记录搜索架构与主题维护约定(不装包、深定制 fork)。
- **子模块主线捋直**:mkdocs-material 远端清理为单分支 master。

## 验证
- 本地 Playwright 实测:搜索「提示词」返回 21 条带高亮结果
- 门禁全绿:git diff --check / mkdocs build / check-characters / upstream-remnants
- 从零 clone 验证子模块可拉取