### PR TITLE
fix(ui): 中文搜索切词与摘要按句切块

### DIFF
--- a/hooks/on_env.py
+++ b/hooks/on_env.py
@@ -1,3 +1,5 @@
+import json
+import os
 import re
 
 def _nav_math():
@@ -21,3 +23,41 @@ def on_config(config, **kwargs):
     except ValueError:
         pass
     return config
+
+def _chunk_sentences(text):
+    """按中文句子边界(。！？!?)切块;无句号的超长块(代码/表格/列表)再按停顿符硬切。"""
+    chunks = []
+    for s in re.split(r"(?<=[。！？!?])", text):
+        s = s.strip()
+        if not s:
+            continue
+        while len(s) > 150:
+            # 在 [20, 120] 区间找最后一个停顿符,找不到就硬切 120 字
+            cut = max([120] + [
+                p for p in (s.rfind(c, 0, 120) for c in "，,、;； ")
+                if p >= 20
+            ])
+            chunks.append(s[: cut + 1].rstrip())
+            s = s[cut + 1:].strip()
+        if s:
+            chunks.append(s)
+    return chunks
+
+def on_post_build(config, **kwargs):
+    # 内置 search 插件把整页文本抹成一行(无 HTML 标签),Material 搜索 worker
+    # 的摘要机制按块级标签切块,于是整页=一块,命中词所在"块"=全文。
+    # 这里把 text 按句子切成 <p> 块,恢复「命中句摘要」(最多两句)。
+    path = os.path.join(config["site_dir"], "search", "search_index.json")
+    if not os.path.exists(path):
+        return
+    with open(path, encoding="utf-8") as f:
+        index = json.load(f)
+    for doc in index.get("docs", []):
+        text = doc.get("text")
+        if not text or "<p>" in text:
+            continue
+        chunks = _chunk_sentences(text)
+        if len(chunks) > 1:
+            doc["text"] = "<p>" + "</p><p>".join(chunks) + "</p>"
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(index, f, ensure_ascii=False)

--- a/hooks/on_env.py
+++ b/hooks/on_env.py
@@ -54,7 +54,9 @@ def on_post_build(config, **kwargs):
         index = json.load(f)
     for doc in index.get("docs", []):
         text = doc.get("text")
-        if not text or "<p>" in text:
+        # 已切块(以 <p> 开头)或正文里本就有 <p> 字样的跳过;用 startswith
+        # 而不是 "in",避免正文含代码示例("<p>")的文档被误判为已处理
+        if not text or text.startswith("<p>"):
             continue
         chunks = _chunk_sentences(text)
         if len(chunks) > 1:


### PR DESCRIPTION
## 内容
- **中文搜索切词差一修复**:主题子模块 `0f0a75cd3` 修复 CJK 切词的位置差一错误(`0580faa` 同步指针,已随 `search-cjk-segment` 分支合入)
- **搜索摘要按句切块**:内置 search 插件把整页文本抹成一行,Material 按标签切块的摘要机制失效导致结果全显全文;`on_post_build` hook 将索引 text 按中文句子切成 `<p>` 块,恢复「命中句摘要」(`01ffa79`)
- **防重判断优化**:切块防重改用 `startswith(<p>)`,避免正文含 `<p>` 字样的文档被误跳过(`85b896f`)

## 验证
- 610/887 个 section 切块生效,幂等(重复执行不翻倍)
- 本地实测:搜索「提示词工程」摘要显示命中句,高亮正常
- 门禁全绿(build / check-characters / upstream-remnants / diff --check)