### PR TITLE
fix(ui): 问答助手面板 instant 换页后保持打开(修复换页即消失)

### DIFF
--- a/docs/_static/css/extra.css
+++ b/docs/_static/css/extra.css
@@ -386,7 +386,7 @@
   color: var(--md-accent-fg-color);
 }
 
-/* 5.6 回顶按钮(浮动控件;#myBtn 见第 10 节) */
+/* 5.6 回顶按钮(内置 .md-top) */
 .md-top {
   background-color: #ffffff;
   border: 1px solid var(--pm-line);
@@ -636,11 +636,6 @@ html {
    9. 响应式(≤760px)
    ---------------------------------------------------------------------------- */
 @media screen and (max-width: 760px) {
-  #myBtn {
-    right: 10px;
-    bottom: 84px;
-  }
-
   .md-content__inner:has(> h1:first-child + hr + blockquote.page-copyright) {
     padding: 2rem 1.2rem;
   }
@@ -674,32 +669,6 @@ details > summary + .highlight > .highlighttable { margin: 0 !important; }
 .headerlink { transform: translateY(-2.5px); }
 
 .md-nav__link[for=__toc] .md-icon { margin-left: auto !important; }
-
-#myBtn {
-    display: none;
-    position: fixed;
-    bottom: 100px;
-    right: 16px;
-    z-index: 99;
-    border: 1px solid var(--pm-line);
-    outline: none;
-    color: var(--pm-muted);
-    background-color: #ffffff;
-    cursor: pointer;
-    padding: .7rem;
-    border-radius: 999px;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, .06);
-    transition: background-color 125ms, color 125ms;
-}
-
-#myBtn:hover {
-    background-color: var(--pm-accent-soft);
-    color: var(--pm-accent);
-}
-
-[data-md-color-scheme="slate"] #myBtn {
-    background-color: #0B0C0F;
-}
 
 #color-button > button {
   cursor: pointer;

--- a/docs/_static/js/chat-widget.js
+++ b/docs/_static/js/chat-widget.js
@@ -8,13 +8,15 @@
   头部 ↗ 可切加宽模式,允许压过正文);移动端降级为全屏覆盖。零依赖原生 JS。
 
   工程契约:
-  - FAB / 面板全部 append 到 document.body 顶层,不带 data-md-component
-    属性 → instant 导航换页整体替换 [data-md-component=container] 时本组件
-    与对话状态存活
+  - FAB append 到 document.body 顶层,不带 data-md-component 属性,instant
+    换页不触碰;面板插在页头交界线之后(与线同族参与 sticky 布局),而
+    instant 导航换页整体替换 [data-md-component=container] 时面板会随旧
+    容器被摘除 —— body 级 MutationObserver 在下一帧按同一规则挂回新
+    容器,对话状态(消息、滚动、流式)原样存活,不随文档跳转消失
   - 打开时隐藏右侧 TOC(md-sidebar--secondary 内层 nav);面板顶边锚定
     页头交界发丝线(.md-header__line,粘性,与吸顶页头同进退),底边停在
     mkdocs 页脚上缘;面板打开期间用 rAF 逐帧对齐 —— 弹性过滚动(滚到
-    顶/底继续拖拽)时浏览器抑制滚动事件,fixed 面板靠逐帧同步不脱节
+    顶/底继续拖拽)时浏览器抑制滚动事件,面板靠逐帧同步不脱节
   - MutationObserver 盯 body 子树:instant 导航换页后新页 TOC 随 container
     重建出现,观察器重新应用隐藏;关闭时还原
   - 与后端契约:POST {message, history} → text/event-stream,帧事件
@@ -124,10 +126,19 @@
       "</div>" +
       '<input type="file" class="aipm-chat__file" multiple hidden>' +
     "</form>";
-  /* 插到页头交界线之后(文档流内,与线一同参与 sticky 布局 —— 结构上
-     不可能与页头/线脱节);线缺失时回退为 body 尾部 */
-  const lineAnchor = document.querySelector(".md-header__line");
-  if (lineAnchor) lineAnchor.after(panel); else document.body.appendChild(panel);
+  /* 挂载点:插到页头交界线之后(文档流内,与线一同参与 sticky 布局 ——
+     结构上不可能与页头/线脱节);线缺失时按 tabs → header → body 回退。
+     instant 换页整体替换 [data-md-component=container],面板随旧容器被
+     摘除,sync() 观察器发现面板脱离文档时按同一规则挂回新容器 */
+  const mount = () => {
+    if (panel.isConnected) return;
+    const anchor = document.querySelector(".md-header__line")
+      || document.querySelector(".md-tabs")
+      || document.querySelector(".md-header");
+    if (anchor) anchor.after(panel);
+    else document.body.appendChild(panel);
+  };
+  mount();
 
   els.fab = fab;
   els.panel = panel;
@@ -750,20 +761,28 @@
 
   /* 面板打开期间逐帧修正高度/水平几何(顶部几何为 sticky 布局自带,
      无需测量):弹性过滚动(滚到顶/底继续拖拽)时浏览器抑制滚动事件,
-     逐帧循环保证高度/边距与页脚、TOC 栏实时一致 */
+     逐帧循环保证高度/边距与页脚、TOC 栏实时一致。
+     alignOn 标志防重复启动:sync 在每次结构变化(含流式输出逐块重写
+     消息区)时都会触发,没有标志会叠出多条并行的逐帧循环 */
+  let alignOn = false;
   const alignLoop = () => {
-    if (!panel.classList.contains("is-open")) return;
+    if (!alignOn) return;
     align();
     requestAnimationFrame(alignLoop);
   };
 
   let rafId = 0;
-  /* 结构变化时统一同步:重新隐藏 TOC(instant 换页后新页 TOC 随 container
-     重建)+ 启动/恢复逐帧对齐循环 */
+  /* 结构变化时统一同步:先把面板挂回文档(instant 换页后旧容器被整体
+     替换,面板随之被摘除,需按 mount 规则重挂到新容器)—— 再重新隐藏
+     新页 TOC(新页 TOC 随 container 重建出现)+ 启动/恢复逐帧对齐循环 */
   const sync = () => {
+    mount();
     if (!panel.classList.contains("is-open")) return;
     applyTocHide(true);
-    alignLoop();
+    if (!alignOn) {
+      alignOn = true;
+      requestAnimationFrame(alignLoop);
+    }
   };
   const scheduleSync = () => {
     cancelAnimationFrame(rafId);
@@ -804,7 +823,10 @@
     panel.setAttribute("aria-hidden", "false");
     els.fab.classList.add("is-hidden");
     applyTocHide(true);
-    alignLoop();   // 启动逐帧对齐(关闭时自停)
+    if (!alignOn) {
+      alignOn = true;
+      requestAnimationFrame(alignLoop);   // 启动逐帧对齐(关闭时自停)
+    }
     scrollBottom(true);
     els.input.focus();
   };
@@ -814,6 +836,7 @@
     panel.setAttribute("aria-hidden", "true");
     els.fab.classList.remove("is-hidden");
     applyTocHide(false);
+    alignOn = false;                      // 停掉逐帧对齐循环
     els.fab.focus();
   };
 

--- a/docs/_static/js/header-line.js
+++ b/docs/_static/js/header-line.js
@@ -7,7 +7,8 @@
   页头 —— 任何状态下始终只有一条线,样式见 extra.css 5.3.1。
 
   重复注入防护:class 已存在即跳过;MutationObserver 兜底 instant 导航
-  换页(header/tabs 不会整体替换,但保险起见)。
+  换页([data-md-component=container] 整体替换,线随旧容器被摘除,由
+  观察器按同一规则重新注入)。
 */
 (() => {
   "use strict";

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -205,7 +205,7 @@ extra:
   # enabled 关闭后不再注入;version 缓存击穿号,改了资源后 +1 即可
   chat_agent:
     enabled: true
-    version: 7
+    version: 8
   # analytics:  # TODO: 需要访问统计时取消注释并填写自己的 ID
   #   provider: google
   #   property: YOUR-GA-ID


### PR DESCRIPTION
## 概述
dev 累积的两个 UI 修复,相对 main 共 3 个提交。

## 修复内容

### 1. 问答助手面板换页后消失(本次 bug 修复)
打开问答助手后点击站内链接跳转,面板消失且无 FAB 可点,只能整页刷新恢复。

**根因**:面板为参与吸顶布局插在页头交界线之后(容器内),instant 导航整体替换 `[data-md-component=container]` 时面板随旧容器被摘除;打开态 FAB 处于 is-hidden,换页后无处可点。

**修复**(`docs/_static/js/chat-widget.js`):
- 挂载逻辑抽成 `mount()`:body 级 MutationObserver 在容器替换后的同帧按 线 → tabs → header → body 规则挂回新容器,面板 DOM、消息、滚动、流式状态原样存活
- `alignOn` 标志防流式输出期间叠出多条并行逐帧对齐循环
- `header-line.js` 注释修正;chat_agent 缓存击穿号 7 → 8

**回归验证**(Playwright,真 instant 导航):打开态连续换页面板保持打开、TOC 保持隐藏;关闭态换页后 FAB 可重新打开;移动端全屏面板同存活。旧代码同场景 panelExists=false + FAB 隐藏,精确复现原 bug。门禁四项全过。

### 2. 移除知乎风格回顶按钮(8bad329)
移除 `#myBtn` 回顶按钮,同步主题子模块 gitlink。