### PR TITLE
ci: 子模块 gitlink 自动同步工作流

### DIFF
--- a/.github/workflows/bump-submodules.yml
+++ b/.github/workflows/bump-submodules.yml
@@ -1,0 +1,54 @@
+name: Bump Submodules
+
+on:
+  schedule:
+    - cron: "17 */6 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: bump-submodules
+  cancel-in-progress: false
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: dev
+          fetch-depth: 1
+      - name: Sync submodule gitlinks
+        run: |
+          set -euo pipefail
+          changed=0
+          for sm in agent-server mkdocs-material; do
+            url=$(git config -f .gitmodules --get "submodule.$sm.url")
+            branch=$(git config -f .gitmodules --get "submodule.$sm.branch")
+            remote_head=$(git ls-remote "$url" "refs/heads/$branch" | awk '{print $1}')
+            pinned=$(git ls-tree HEAD "$sm" | awk '{print $3}')
+            if [ -z "$remote_head" ]; then
+              echo "::warning::$sm 无法获取 $branch 远端 HEAD,跳过"
+              continue
+            fi
+            if [ "$remote_head" = "$pinned" ]; then
+              echo "$sm: 已是最新 ($pinned)"
+              continue
+            fi
+            echo "::notice::$sm: gitlink $pinned -> $remote_head"
+            git submodule update --init "$sm"
+            git -C "$sm" fetch origin "$branch"
+            git -C "$sm" checkout -q "$remote_head"
+            git add "$sm"
+            changed=1
+          done
+          if [ "$changed" -eq 1 ]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git commit -m "chore(deps): 子模块 gitlink 自动同步至远端 HEAD"
+            git push origin dev
+            echo "已推送 dev"
+          else
+            echo "所有子模块均已是最新"
+          fi

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "mkdocs-material"]
 	path = mkdocs-material
 	url = https://github.com/AI-PM-Wiki/mkdocs-material
+	branch = master
 [submodule "agent-server"]
 	path = agent-server
 	url = https://github.com/AI-PM-Wiki/aipm-agent-server
+	branch = main


### PR DESCRIPTION
## 变更内容

- 新增 `.github/workflows/bump-submodules.yml`:定时(每 6 小时 + 手动 dispatch)轮询 `agent-server`(main)与 `mkdocs-material`(master)的远端 HEAD,与 wiki 树里的 gitlink 比较,不一致时自动 bump 并提交到 dev
- `.gitmodules` 为两个子模块补充 `branch` 字段(工作流追踪依据)

## 说明

- 零额外凭证:GITHUB_TOKEN 即可推送 dev(无分支保护);不会触发生成 CI 循环(该工作流只被 schedule/manual 触发)
- bump 落在 dev,随下次发布 PR 进 main(符合既有发布流程)
- 首次运行会把 agent-server gitlink 从 a4079b5 修到当前远端 HEAD(a8780f9)