### PR TITLE
chore(config): dependabot 仅保留 gitsubmodule 扫描,移除 npm/pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@
 # 注意:gitsubmodule 生态覆盖 .gitmodules 里**全部**子模块,包括定制主题
 # mkdocs-material——主题是手动维护的定制 fork,收到其 PR 直接忽略即可,
 # 不要自动合并。
+#
+# 曾配置的 npm/pip 扫描已于 2026-08-24 移除:package.json 依赖为 oi-wiki
+# fork 遗留且本项目刻意不用(node_modules 未装、门禁零 Node 依赖);pip 依赖
+# 由 uv.lock 权威锁定(pyproject 精确 `==`),升级走 `uv update` 人工跑门禁,
+# Dependabot 只改 pyproject 不动 lockfile,只会开半成品 PR。
 version: 2
 updates:
   - package-ecosystem: "gitsubmodule"
@@ -17,23 +22,5 @@ updates:
       day: "monday"
       time: "09:30"
     open-pull-requests-limit: 2
-    commit-message:
-      prefix: "chore(deps)"
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:30"
-    open-pull-requests-limit: 5
-    commit-message:
-      prefix: "chore(deps)"
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "09:30"
-    open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"


### PR DESCRIPTION
## 背景

`.github/dependabot.yml`(今天 efd9f76 更新)同时扫描 npm/pip,但:

- package.json 依赖是 oi-wiki fork 遗留、本项目刻意不用(node_modules 未装、门禁零 Node 依赖)
- pip 依赖由 uv.lock 权威锁定(pyproject 精确 `==`),升级走 `uv update` 人工跑门禁;Dependabot 的 pip PR 只改 pyproject 一行、不动 uv.lock,是半成品

今天已自动开出 PR #17–#23(全部未合并,已随分支一并关闭删除)。

## 变更

dependabot.yml 只保留 gitsubmodule 生态(agent-server gitlink 自动更新,与注释本意一致);npm/pip 段移除并注释原因。

> 注意:Dependabot 读取**默认分支(main)** 的配置,本 PR 合并后才真正生效。