### PR TITLE
首页深海玻璃重构:黑蓝深海 × 玻璃 UI × ASCII 仪器(双风格)

### DIFF
--- a/docs/_static/css/extra.css
+++ b/docs/_static/css/extra.css
@@ -708,104 +708,44 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
 }
 
 /* ----------------------------------------------------------------------------
-   11. 首页 hero / 卡片 / 按钮(深海玻璃:abyss 底 + sonar 青 + mono 仪器风,
-       2026-08-25 用户指令改版「黑蓝深海 / 玻璃 UI / ASCII 原子像素」)
+   11. 首页 hero / 卡片 / 按钮(玻璃 UI + sonar 青 + mono 仪器风;
+       2026-08-25 用户指令改版「黑蓝深海 / 玻璃 UI / ASCII 原子像素」,
+       同日打磨:hero 去除大面积深色带与流动光效,背景与站点其余页面一致
+       (亮=站点亮底 / 暗=站点暗底),深海视觉收敛到 banner 视口卡内)
    ---------------------------------------------------------------------------- */
 
-/* 11.0 深海设计 token(hero 恒用,不随主题——「海面下永远黑暗」);
-      页身随主题,见 11.1 / 11.5 的 data-md-color-scheme 前缀规则 */
+/* 11.0 深海设计 token:供玻璃卡片(slate 侧)/按钮/banner 使用;
+      hero 文字不再硬编码深海浅色,随 --md-default-fg-color 主题化 */
 :root {
-  --pm-dive-abyss: #04070D;                         /* hero 底(近似黑的海蓝) */
-  --pm-dive-trench: #0A1428;                        /* 玻璃面板基色 */
+  --pm-dive-abyss: #04070D;                         /* primary 按钮文字(青底深字) */
   --pm-dive-sonar: #22D3EE;                         /* 生物荧光青 accent */
-  --pm-dive-sea: #3B82F6;                           /* 深蓝辅助 */
-  --pm-dive-phosphor: #A5F3FC;                      /* 高亮文字/微光 */
-  --pm-dive-ink: #E6F0FA;                           /* hero 主文字 */
-  --pm-dive-muted: #7E9CC0;                         /* 次级文字/发丝线 */
+  --pm-dive-phosphor: #A5F3FC;                      /* 暗底高亮文字/微光 */
+  --pm-dive-ink: #E6F0FA;                           /* slate 侧卡片主文字 */
   --pm-dive-line: rgba(148, 196, 255, .18);         /* 玻璃描边/分隔 */
 }
 
 /* 11.1 首页容器:与 .md-grid 同宽,正文等宽居中;
-   页身「潜航器甲板」玻璃面板,随主题(亮=海面 / 暗=深海玻璃);
-   面板背景挂在 ::before 且横向外扩——内容(卡片/原则/note)与 hero banner
-   保持同一 61rem 对齐,边框与内容之间留出均匀的「甲板沿」 */
+   2026-08-25 打磨:去除「潜航器甲板」玻璃面板(原 ::before 渐变底+描边+inset 高光),
+   与站点正文背景融为一体——卡片直接坐落在站点背景上(同旧版首页观感) */
 .pm-home-body {
-  position: relative;
-  isolation: isolate;
   max-width: 61rem;
-  margin: .85rem auto 0;   /* 与 hero 分隔发丝线之间留出浅色呼吸带 */
-  padding: 1.1rem 0 1.4rem;
+  margin: 0 auto;
 }
 
-.pm-home-body::before {
-  content: "";
-  position: absolute;
-  inset: 0 -.9rem;
-  z-index: -1;
-  border: 1px solid var(--pm-dive-line);
-  border-radius: 16px;
-  pointer-events: none;
-}
-
-[data-md-color-scheme="default"] .pm-home-body::before {
-  background: linear-gradient(180deg, #F5F9FD 0%, #EAF2FA 100%);
-  border-color: rgba(34, 211, 238, .28);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .8);
-}
-
-[data-md-color-scheme="slate"] .pm-home-body::before {
-  background: linear-gradient(180deg, rgba(10, 20, 40, .5), rgba(6, 13, 26, .68));
-  border-color: rgba(148, 196, 255, .14);
-}
-
-/* 11.2 hero:「知识潜航器」视口,永恒深海
-   (abyss 底 + 极缓洋流光斑;深色带横向延展到内容列边缘,顶贴 tabs 发丝线) */
+/* 11.2 hero:「知识潜航器」页首——站点背景,不设底色/不外扩/无流动光效;
+   (2026-08-25 打磨:hero 与站点其余页面同底,亮=站点亮底 / 暗=站点暗底,
+   视觉重心收敛在 banner 视口卡内;深海画只存在于卡内) */
 .pm-hero {
-  position: relative;
-  isolation: isolate;
-  overflow: hidden;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: .9rem;
-  margin-block-start: -1.25rem;   /* 抵消 content__inner 顶部留白,深色带贴 tabs */
-  margin-inline: -1rem;
-  padding: 2.6rem 0 2.1rem;       /* 横向不设 padding:banner 与卡片列同宽对齐 */
+  padding: 1.1rem 0 .9rem;   /* 顶部承 content__inner 的 .6rem,底部接卡片网格 */
   text-align: center;
-  color: var(--pm-dive-ink);
-  background-color: var(--pm-dive-abyss);
-  border-bottom: 1px solid rgba(148, 196, 255, .14); /* hero 与甲板的分隔发丝线 */
 }
 
-@media screen and (min-width: 960px) {
-  .pm-hero { margin-inline: -1.5rem -1rem; } /* 导航树现身后,左右留白不对称 */
-}
-
-@media screen and (min-width: 1220px) {
-  .pm-hero { margin-inline: -1.5rem; }       /* 双侧内容列边距均为 1.5rem */
-}
-
-/* 洋流光斑:两团大尺度 radial 光斑极缓漂移(RM 下静态,见 11.7) */
-.pm-hero::before {
-  content: "";
-  position: absolute;
-  inset: 0;
-  z-index: -1;
-  background:
-    radial-gradient(42% 60% at 18% 22%, rgba(59, 130, 246, .16), transparent 72%),
-    radial-gradient(34% 52% at 82% 74%, rgba(34, 211, 238, .09), transparent 70%),
-    radial-gradient(26% 40% at 55% 8%, rgba(165, 243, 252, .05), transparent 70%);
-  animation: pm-drift 34s ease-in-out infinite alternate;
-  pointer-events: none;
-}
-
-@keyframes pm-drift {
-  from { transform: translate3d(-1.5%, -1%, 0); }
-  to   { transform: translate3d(1.5%, 1.2%, 0) scale(1.04); }
-}
-
-/* 眉题:仪器风格的 mono 小字 + 「//」前缀 + CSS 方块闪烁光标(不用字形) */
+/* 眉题:仪器风格的 mono 小字 + 「//」前缀 + 静态方块光标(不闪烁,去晕眩) */
 .pm-hero__eyebrow {
   margin: 0;
   font-family: var(--md-code-font);
@@ -813,7 +753,7 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
   font-weight: 500;
   letter-spacing: .3em;
   text-transform: uppercase;
-  color: var(--pm-dive-muted);
+  color: var(--md-default-fg-color--light);
 }
 
 .pm-hero__eyebrow::before {
@@ -829,24 +769,17 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
   margin-left: .62em;
   vertical-align: -.14em;
   background-color: var(--pm-dive-sonar);
-  opacity: .9;
-  animation: pm-blink 1.1s steps(1, end) infinite;
+  opacity: .55;
 }
 
-@keyframes pm-blink {
-  50% { opacity: 0; }
-}
-
-/* 品牌:phosphor 微光(字重/字距微调,字体不变) */
+/* 品牌:主题前景色(亮=深字 / 暗=浅字),无发光晕 */
 .pm-hero .site-name {
   margin: 0;
   font-size: 2.4rem;
   font-weight: 700;
   line-height: 1.2;
   letter-spacing: .02em;
-  color: var(--pm-dive-ink);
-  text-shadow: 0 0 26px rgba(165, 243, 252, .25),
-               0 0 8px rgba(34, 211, 238, .16);
+  color: var(--md-default-fg-color);
 }
 
 .pm-hero .tagline {
@@ -854,12 +787,13 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
   margin: .2rem auto 0;
   font-size: 1rem;
   line-height: 1.7;
-  color: var(--pm-dive-muted);
+  color: var(--md-default-fg-color--light);
   text-wrap: balance; /* 避免末行孤字 */
 }
 
-/* 视口 HUD 状态行:紧贴 banner 下缘的 mono 状态行(静态值 + CSS 光标闪烁);
-   行体挂 brand::before,光标挂 brand::after(absolute,贴行右端) */
+/* 视口 HUD 状态行:紧贴 banner 下缘的 mono 状态行(静态值 + 静态光标,不闪烁);
+   行体挂 brand::before,光标挂 brand::after(absolute,贴行右端);
+   行色/发丝刻度随主题前景色 */
 .pm-hero__brand {
   position: relative;
 }
@@ -875,10 +809,10 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
   line-height: 1.1;
   letter-spacing: .22em;
   text-align: center;
-  color: rgba(126, 156, 192, .85);
+  color: var(--md-default-fg-color--light);
   background-image:
-    linear-gradient(90deg, rgba(148, 196, 255, .32), rgba(148, 196, 255, .32)) left center / 10% 1px no-repeat,
-    linear-gradient(90deg, rgba(148, 196, 255, .32), rgba(148, 196, 255, .32)) right center / 10% 1px no-repeat;
+    linear-gradient(90deg, var(--md-default-fg-color--lightest), var(--md-default-fg-color--lightest)) left center / 10% 1px no-repeat,
+    linear-gradient(90deg, var(--md-default-fg-color--lightest), var(--md-default-fg-color--lightest)) right center / 10% 1px no-repeat;
 }
 
 .pm-hero__brand::after {
@@ -889,9 +823,8 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
   width: .48em;
   height: 1em;
   font-size: .58rem;      /* 与 HUD 行同字号,em 对齐 */
-  background-color: var(--pm-dive-phosphor);
-  opacity: .85;
-  animation: pm-blink 1.1s steps(1, end) infinite;
+  background-color: var(--pm-dive-sonar);
+  opacity: .55;
 }
 
 .pm-hero__cta {
@@ -908,7 +841,8 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
    优先级高于 `.pm-btn`(0,1,0),会覆盖按钮文字色;故所有作用于 <a> 按钮的规则
    都配 `.md-typeset a.pm-btn…` 前置选择器提权(0,2,1/0,3,1)。
    `.pm-btn--search` 是 <button>,不适用,保留原选择器。
-   hero 恒深海,按钮样式不随主题,无 slate 分支(海面下永远黑暗)。 */
+   hero 随主题后,ghost/search 玻璃底与文字色也按主题分支(亮=白玻璃 /
+   暗=trench 玻璃);primary 仍是 sonar 青实底(两种主题下都成立)。 */
 .md-typeset a.pm-btn,
 .pm-btn {
   display: inline-flex;
@@ -967,10 +901,20 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
               0 0 22px rgba(165, 243, 252, .28);
 }
 
-/* 幽灵按钮:trench 玻璃 + 发丝描边 + hover sonar 青辉 */
+/* 幽灵按钮:主题玻璃 + 发丝描边 + hover sonar 青辉 */
 .md-typeset a.pm-btn--ghost,
 .pm-btn--ghost {
-  color: var(--pm-dive-ink);
+  color: var(--md-default-fg-color);
+}
+
+[data-md-color-scheme="default"] .md-typeset a.pm-btn--ghost,
+[data-md-color-scheme="default"] .pm-btn--ghost {
+  background-color: rgba(255, 255, 255, .65);
+  border-color: rgba(34, 211, 238, .3);
+}
+
+[data-md-color-scheme="slate"] .md-typeset a.pm-btn--ghost,
+[data-md-color-scheme="slate"] .pm-btn--ghost {
   background-color: rgba(10, 20, 40, .45);
   border-color: var(--pm-dive-line);
 }
@@ -981,13 +925,34 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
 .pm-btn--ghost:focus-visible {
   background-color: rgba(34, 211, 238, .12);
   border-color: var(--pm-dive-sonar);
+}
+
+[data-md-color-scheme="default"] .md-typeset a.pm-btn--ghost:hover,
+[data-md-color-scheme="default"] .md-typeset a.pm-btn--ghost:focus-visible,
+[data-md-color-scheme="default"] .pm-btn--ghost:hover,
+[data-md-color-scheme="default"] .pm-btn--ghost:focus-visible {
+  color: #0E7490; /* 亮底上 sonar 对比不足,提为同系深青 */
+}
+
+[data-md-color-scheme="slate"] .md-typeset a.pm-btn--ghost:hover,
+[data-md-color-scheme="slate"] .md-typeset a.pm-btn--ghost:focus-visible,
+[data-md-color-scheme="slate"] .pm-btn--ghost:hover,
+[data-md-color-scheme="slate"] .pm-btn--ghost:focus-visible {
   color: var(--pm-dive-phosphor);
 }
 
 /* 搜索按钮:ghost 胶囊 + 放大镜图标(纯样式,点击聚焦行为在模板) */
 .pm-btn--search {
   border-radius: 999px;
-  color: var(--pm-dive-muted);
+  color: var(--md-default-fg-color--light);
+}
+
+[data-md-color-scheme="default"] .pm-btn--search {
+  background-color: rgba(255, 255, 255, .65);
+  border-color: rgba(34, 211, 238, .3);
+}
+
+[data-md-color-scheme="slate"] .pm-btn--search {
   background-color: rgba(10, 20, 40, .45);
   border-color: var(--pm-dive-line);
 }
@@ -1004,9 +969,18 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
 
 .pm-btn--search:hover,
 .pm-btn--search:focus-visible {
-  color: var(--pm-dive-phosphor);
   background-color: rgba(34, 211, 238, .12);
   border-color: var(--pm-dive-sonar);
+}
+
+[data-md-color-scheme="default"] .pm-btn--search:hover,
+[data-md-color-scheme="default"] .pm-btn--search:focus-visible {
+  color: #0E7490;
+}
+
+[data-md-color-scheme="slate"] .pm-btn--search:hover,
+[data-md-color-scheme="slate"] .pm-btn--search:focus-visible {
+  color: var(--pm-dive-phosphor);
 }
 
 /* 11.4 卡片网格:桌面 3 列 → 平板 2 列 → 移动 1 列 */
@@ -1165,16 +1139,8 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
 
 /* 11.6 响应式 hero 与按钮(窄屏:HUD 缩短,视口角框淡出) */
 @media screen and (max-width: 600px) {
-  .pm-home-body {
-    padding: .9rem 0 1.1rem;
-  }
-
-  .pm-home-body::before {
-    inset: 0 -.6rem; /* 窄屏外扩收敛(内容 margin 16px,按钮不贴边) */
-  }
-
   .pm-hero {
-    padding: 2rem 1rem 1.75rem;
+    padding: 1.4rem 0 1.2rem; /* 无深色带/外扩,仅垂直留白 */
   }
 
   /* 眉题:窄屏收敛字距/字号,防整句右溢裁切(完整显示,光标块对齐) */
@@ -1210,7 +1176,7 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
   }
 }
 
-/* 11.7 减少动态:关闭位移过渡与深海动画(洋流/光标闪烁)的静态回退 */
+/* 11.7 减少动态:关闭位移过渡的静态回退(hero 洋流/光标闪烁已移除,无动画可关) */
 @media (prefers-reduced-motion: reduce) {
   .md-typeset a.pm-btn,
   .pm-btn,
@@ -1225,12 +1191,6 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
   .pm-card:hover,
   .pm-card:focus-visible {
     transform: none;
-  }
-
-  .pm-hero::before,
-  .pm-hero__eyebrow::after,
-  .pm-hero__brand::after {
-    animation: none;
   }
 }
 
@@ -1354,7 +1314,7 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
        视口四角 ASCII 折线 + 顶条 VESSEL.SYS + 生物荧光粒子流(JS ink 层);
        domain-warped fbm 标量场 / 电荷 / 字形雕刻等契约全部不变。
        token 七色:细线/计曲线/网格/字形洗色/正文/浅淡(标签)/强调,
-       hero 恒深海 → 亮暗两套同色(「海面下永远黑暗」);JS 只解析
+       banner 卡内深海画不随主题(视口内自成一格)→ 亮暗两套同色;JS 只解析
        hex/rgb()/rgba(),token 请勿用 hsl()/hsla()。
    ---------------------------------------------------------------------------- */
 :root {

--- a/docs/_static/css/extra.css
+++ b/docs/_static/css/extra.css
@@ -708,45 +708,145 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
 }
 
 /* ----------------------------------------------------------------------------
-   11. 首页 hero / 卡片 / 按钮(hpc101 式简洁:无玻璃、无光晕、无动画)
+   11. 首页 hero / 卡片 / 按钮(深海玻璃:abyss 底 + sonar 青 + mono 仪器风,
+       2026-08-25 用户指令改版「黑蓝深海 / 玻璃 UI / ASCII 原子像素」)
    ---------------------------------------------------------------------------- */
 
-/* 11.1 首页容器:与 .md-grid 同宽,正文等宽居中 */
-.pm-home-body {
-  max-width: 61rem;
-  margin-right: auto;
-  margin-left: auto;
+/* 11.0 深海设计 token(hero 恒用,不随主题——「海面下永远黑暗」);
+      页身随主题,见 11.1 / 11.5 的 data-md-color-scheme 前缀规则 */
+:root {
+  --pm-dive-abyss: #04070D;                         /* hero 底(近似黑的海蓝) */
+  --pm-dive-trench: #0A1428;                        /* 玻璃面板基色 */
+  --pm-dive-sonar: #22D3EE;                         /* 生物荧光青 accent */
+  --pm-dive-sea: #3B82F6;                           /* 深蓝辅助 */
+  --pm-dive-phosphor: #A5F3FC;                      /* 高亮文字/微光 */
+  --pm-dive-ink: #E6F0FA;                           /* hero 主文字 */
+  --pm-dive-muted: #7E9CC0;                         /* 次级文字/发丝线 */
+  --pm-dive-line: rgba(148, 196, 255, .18);         /* 玻璃描边/分隔 */
 }
 
-/* 11.2 hero:层级 eyebrow > banner > h1 > tagline > 按钮;子元素入场编排见 11.8 */
+/* 11.1 首页容器:与 .md-grid 同宽,正文等宽居中;
+   页身「潜航器甲板」玻璃面板,随主题(亮=海面 / 暗=深海玻璃);
+   面板背景挂在 ::before 且横向外扩——内容(卡片/原则/note)与 hero banner
+   保持同一 61rem 对齐,边框与内容之间留出均匀的「甲板沿」 */
+.pm-home-body {
+  position: relative;
+  isolation: isolate;
+  max-width: 61rem;
+  margin: .85rem auto 0;   /* 与 hero 分隔发丝线之间留出浅色呼吸带 */
+  padding: 1.1rem 0 1.4rem;
+}
+
+.pm-home-body::before {
+  content: "";
+  position: absolute;
+  inset: 0 -.9rem;
+  z-index: -1;
+  border: 1px solid var(--pm-dive-line);
+  border-radius: 16px;
+  pointer-events: none;
+}
+
+[data-md-color-scheme="default"] .pm-home-body::before {
+  background: linear-gradient(180deg, #F5F9FD 0%, #EAF2FA 100%);
+  border-color: rgba(34, 211, 238, .28);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .8);
+}
+
+[data-md-color-scheme="slate"] .pm-home-body::before {
+  background: linear-gradient(180deg, rgba(10, 20, 40, .5), rgba(6, 13, 26, .68));
+  border-color: rgba(148, 196, 255, .14);
+}
+
+/* 11.2 hero:「知识潜航器」视口,永恒深海
+   (abyss 底 + 极缓洋流光斑;深色带横向延展到内容列边缘,顶贴 tabs 发丝线) */
 .pm-hero {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
   gap: .9rem;
-  padding: 2.75rem 1rem 2.25rem;
+  margin-block-start: -1.25rem;   /* 抵消 content__inner 顶部留白,深色带贴 tabs */
+  margin-inline: -1rem;
+  padding: 2.6rem 0 2.1rem;       /* 横向不设 padding:banner 与卡片列同宽对齐 */
   text-align: center;
+  color: var(--pm-dive-ink);
+  background-color: var(--pm-dive-abyss);
+  border-bottom: 1px solid rgba(148, 196, 255, .14); /* hero 与甲板的分隔发丝线 */
 }
 
-/* 眉题:等宽大写小字,与 banner 的 micro 标签同语言 */
+@media screen and (min-width: 960px) {
+  .pm-hero { margin-inline: -1.5rem -1rem; } /* 导航树现身后,左右留白不对称 */
+}
+
+@media screen and (min-width: 1220px) {
+  .pm-hero { margin-inline: -1.5rem; }       /* 双侧内容列边距均为 1.5rem */
+}
+
+/* 洋流光斑:两团大尺度 radial 光斑极缓漂移(RM 下静态,见 11.7) */
+.pm-hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background:
+    radial-gradient(42% 60% at 18% 22%, rgba(59, 130, 246, .16), transparent 72%),
+    radial-gradient(34% 52% at 82% 74%, rgba(34, 211, 238, .09), transparent 70%),
+    radial-gradient(26% 40% at 55% 8%, rgba(165, 243, 252, .05), transparent 70%);
+  animation: pm-drift 34s ease-in-out infinite alternate;
+  pointer-events: none;
+}
+
+@keyframes pm-drift {
+  from { transform: translate3d(-1.5%, -1%, 0); }
+  to   { transform: translate3d(1.5%, 1.2%, 0) scale(1.04); }
+}
+
+/* 眉题:仪器风格的 mono 小字 + 「//」前缀 + CSS 方块闪烁光标(不用字形) */
 .pm-hero__eyebrow {
   margin: 0;
   font-family: var(--md-code-font);
-  font-size: .68rem;
-  font-weight: 600;
-  letter-spacing: .24em;
+  font-size: .66rem;
+  font-weight: 500;
+  letter-spacing: .3em;
   text-transform: uppercase;
-  color: var(--pm-accent);
+  color: var(--pm-dive-muted);
 }
 
+.pm-hero__eyebrow::before {
+  content: "// ";
+  color: var(--pm-dive-sonar);
+}
+
+.pm-hero__eyebrow::after {
+  content: "";
+  display: inline-block;
+  width: .52em;
+  height: 1.1em;
+  margin-left: .62em;
+  vertical-align: -.14em;
+  background-color: var(--pm-dive-sonar);
+  opacity: .9;
+  animation: pm-blink 1.1s steps(1, end) infinite;
+}
+
+@keyframes pm-blink {
+  50% { opacity: 0; }
+}
+
+/* 品牌:phosphor 微光(字重/字距微调,字体不变) */
 .pm-hero .site-name {
   margin: 0;
   font-size: 2.4rem;
   font-weight: 700;
   line-height: 1.2;
-  letter-spacing: -.02em;
-  color: var(--pm-ink);
+  letter-spacing: .02em;
+  color: var(--pm-dive-ink);
+  text-shadow: 0 0 26px rgba(165, 243, 252, .25),
+               0 0 8px rgba(34, 211, 238, .16);
 }
 
 .pm-hero .tagline {
@@ -754,8 +854,44 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
   margin: .2rem auto 0;
   font-size: 1rem;
   line-height: 1.7;
-  color: var(--pm-muted);
+  color: var(--pm-dive-muted);
   text-wrap: balance; /* 避免末行孤字 */
+}
+
+/* 视口 HUD 状态行:紧贴 banner 下缘的 mono 状态行(静态值 + CSS 光标闪烁);
+   行体挂 brand::before,光标挂 brand::after(absolute,贴行右端) */
+.pm-hero__brand {
+  position: relative;
+}
+
+.pm-hero__brand::before {
+  content: "SONAR.OK ▸ DEPTH 342M ▸ MOD 07/07 ▸ SIGNAL LOCKED";
+  display: block;
+  margin-top: -1.1rem;   /* 抵消 hero gap + banner 下边距,贴住视口底缘 */
+  padding: .35rem 13% .2rem;
+  font-family: var(--md-code-font);
+  font-size: .58rem;
+  font-weight: 500;
+  line-height: 1.1;
+  letter-spacing: .22em;
+  text-align: center;
+  color: rgba(126, 156, 192, .85);
+  background-image:
+    linear-gradient(90deg, rgba(148, 196, 255, .32), rgba(148, 196, 255, .32)) left center / 10% 1px no-repeat,
+    linear-gradient(90deg, rgba(148, 196, 255, .32), rgba(148, 196, 255, .32)) right center / 10% 1px no-repeat;
+}
+
+.pm-hero__brand::after {
+  content: "";
+  position: absolute;
+  top: -.72rem;           /* 与 HUD 行文本中心对齐(行顶 -1.1rem + 文本偏移) */
+  right: 3.5%;
+  width: .48em;
+  height: 1em;
+  font-size: .58rem;      /* 与 HUD 行同字号,em 对齐 */
+  background-color: var(--pm-dive-phosphor);
+  opacity: .85;
+  animation: pm-blink 1.1s steps(1, end) infinite;
 }
 
 .pm-hero__cta {
@@ -767,11 +903,12 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
   margin-top: .2rem;
 }
 
-/* 11.3 按钮(.pm-btn 系)
+/* 11.3 按钮(玻璃胶囊)
    注:`.md-typeset a`(0,1,1)与 `md-typeset a:focus/:hover`(0,2,1)的链接色
    优先级高于 `.pm-btn`(0,1,0),会覆盖按钮文字色;故所有作用于 <a> 按钮的规则
    都配 `.md-typeset a.pm-btn…` 前置选择器提权(0,2,1/0,3,1)。
-   `.pm-btn--search` 是 <button>,不适用,保留原选择器。 */
+   `.pm-btn--search` 是 <button>,不适用,保留原选择器。
+   hero 恒深海,按钮样式不随主题,无 slate 分支(海面下永远黑暗)。 */
 .md-typeset a.pm-btn,
 .pm-btn {
   display: inline-flex;
@@ -780,7 +917,7 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
   gap: .5em;
   padding: .6em 1.4em;
   border: 1px solid transparent;
-  border-radius: 8px;
+  border-radius: 999px;
   font-family: inherit;
   font-size: .95rem;
   font-weight: 600;
@@ -807,59 +944,52 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
 
 .md-typeset a.pm-btn:focus-visible,
 .pm-btn:focus-visible {
-  outline: 2px solid var(--pm-accent);
+  outline: 2px solid var(--pm-dive-sonar);
   outline-offset: 2px;
 }
 
-/* 主按钮:accent 实色底 + 白字 + hover 加深(无渐变) */
+/* 主按钮:sonar 荧光青实底 + 深海深字 + hover 提为 phosphor(生物荧光) */
 .md-typeset a.pm-btn--primary,
 .pm-btn--primary {
-  color: #ffffff;
-  background-color: #4051b5;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, .08);
+  color: var(--pm-dive-abyss);
+  background-color: var(--pm-dive-sonar);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, .35),
+              0 0 18px rgba(34, 211, 238, .18);
 }
 
 .md-typeset a.pm-btn--primary:hover,
 .md-typeset a.pm-btn--primary:focus-visible,
 .pm-btn--primary:hover,
 .pm-btn--primary:focus-visible {
-  color: #ffffff;
-  background-color: #3a4aa5;
-  box-shadow: 0 2px 6px rgba(64, 81, 181, .28);
+  color: var(--pm-dive-abyss);
+  background-color: var(--pm-dive-phosphor);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, .35),
+              0 0 22px rgba(165, 243, 252, .28);
 }
 
-/* 幽灵按钮:白底 + 细边框 + hover 淡蓝底 */
+/* 幽灵按钮:trench 玻璃 + 发丝描边 + hover sonar 青辉 */
 .md-typeset a.pm-btn--ghost,
 .pm-btn--ghost {
-  color: var(--pm-ink);
-  background-color: #ffffff;
-  border-color: var(--pm-line);
-}
-
-[data-md-color-scheme="slate"] .md-typeset a.pm-btn--ghost,
-[data-md-color-scheme="slate"] .pm-btn--ghost {
-  background-color: transparent;
+  color: var(--pm-dive-ink);
+  background-color: rgba(10, 20, 40, .45);
+  border-color: var(--pm-dive-line);
 }
 
 .md-typeset a.pm-btn--ghost:hover,
 .md-typeset a.pm-btn--ghost:focus-visible,
 .pm-btn--ghost:hover,
 .pm-btn--ghost:focus-visible {
-  background-color: var(--pm-accent-soft);
-  border-color: var(--pm-accent);
-  color: var(--pm-accent);
+  background-color: rgba(34, 211, 238, .12);
+  border-color: var(--pm-dive-sonar);
+  color: var(--pm-dive-phosphor);
 }
 
 /* 搜索按钮:ghost 胶囊 + 放大镜图标(纯样式,点击聚焦行为在模板) */
 .pm-btn--search {
   border-radius: 999px;
-  color: var(--pm-muted);
-  background-color: #ffffff;
-  border-color: var(--pm-line);
-}
-
-[data-md-color-scheme="slate"] .pm-btn--search {
-  background-color: transparent;
+  color: var(--pm-dive-muted);
+  background-color: rgba(10, 20, 40, .45);
+  border-color: var(--pm-dive-line);
 }
 
 .pm-btn--search::before {
@@ -874,9 +1004,9 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
 
 .pm-btn--search:hover,
 .pm-btn--search:focus-visible {
-  color: var(--pm-accent);
-  background-color: var(--pm-accent-soft);
-  border-color: var(--pm-accent);
+  color: var(--pm-dive-phosphor);
+  background-color: rgba(34, 211, 238, .12);
+  border-color: var(--pm-dive-sonar);
 }
 
 /* 11.4 卡片网格:桌面 3 列 → 平板 2 列 → 移动 1 列 */
@@ -884,7 +1014,7 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
   gap: 16px;
-  padding: 1.5rem 0 3rem;
+  padding: .9rem 0 2rem;
 }
 
 @media screen and (max-width: 960px) {
@@ -899,23 +1029,69 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
   }
 }
 
-/* 11.5 栏目卡片:白底(暗:hsla(225,15%,7%))+ 细边框 + hover 上浮 accent;
-   无玻璃、无光晕 */
+/* 11.5 栏目卡片:玻璃(blur + 1px 青描边 + 顶部高光),随主题:
+   亮 = 海面白玻璃 / 暗 = trench 深海玻璃;hover 上浮 + 青辉 + 角像素点 */
 .pm-card {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: .5rem;
   padding: 1.25rem;
-  border: 1px solid var(--pm-line);
-  border-radius: 8px;
-  background-color: var(--pm-card-bg);
-  color: var(--pm-ink);
+  border: 1px solid var(--pm-dive-line);
+  border-radius: 12px;
   text-decoration: none;
   transition: transform 150ms ease, box-shadow 150ms ease,
               border-color 150ms ease, background-color 150ms ease;
 }
 
-/* 卡片图标:手绘 stroke 风(lucide 语言),faint → hover accent */
+[data-md-color-scheme="default"] .pm-card {
+  background-color: rgba(255, 255, 255, .66);
+  border-color: rgba(34, 211, 238, .3);
+  color: #0F1B2D;
+  box-shadow: 0 1px 3px rgba(15, 27, 45, .05),
+              inset 0 1px 0 rgba(255, 255, 255, .9);
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+}
+
+[data-md-color-scheme="slate"] .pm-card {
+  background-color: rgba(10, 20, 40, .52);
+  border-color: rgba(148, 196, 255, .16);
+  color: var(--pm-dive-ink);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, .3),
+              inset 0 1px 0 rgba(148, 196, 255, .08);
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+}
+
+/* 顶部高光:青系发丝,恒亮 */
+.pm-card::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 14%;
+  right: 14%;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(34, 211, 238, .55), transparent);
+  pointer-events: none;
+}
+
+/* hover 角像素点:右上角 ASCII 折角,呼应视口框语言 */
+.pm-card::after {
+  content: "";
+  position: absolute;
+  top: .5rem;
+  right: .5rem;
+  width: 7px;
+  height: 7px;
+  border-top: 1px solid var(--pm-dive-sonar);
+  border-right: 1px solid var(--pm-dive-sonar);
+  opacity: 0;
+  transition: opacity 150ms ease;
+  pointer-events: none;
+}
+
+/* 卡片图标:手绘 stroke 风(lucide 语言),sonar 青;暗色 hover 提为 phosphor */
 .pm-card__icon {
   width: 22px;
   height: 22px;
@@ -925,45 +1101,76 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
   stroke-width: 1.7;
   stroke-linecap: round;
   stroke-linejoin: round;
-  color: var(--pm-faint);
-  transition: color 150ms ease;
+  color: var(--pm-dive-sonar);
+  transition: color 150ms ease, opacity 150ms ease;
+}
+
+[data-md-color-scheme="default"] .pm-card__icon {
+  opacity: .9;
+}
+
+[data-md-color-scheme="slate"] .pm-card__icon {
+  opacity: .95;
 }
 
 .pm-card__title {
   font-size: 1rem;
   font-weight: 700;
   line-height: 1.4;
-  color: var(--pm-ink);
+  color: inherit;
   transition: color 150ms ease;
 }
 
 .pm-card__desc {
   font-size: .85rem;
   line-height: 1.65;
-  color: var(--pm-muted);
+  color: inherit;
+  opacity: .68;
 }
 
 .pm-card:hover,
 .pm-card:focus-visible {
   transform: translateY(-2px);
-  border-color: var(--pm-accent);
-  box-shadow: var(--pm-card-hover-shadow);
+  border-color: rgba(34, 211, 238, .55);
+  box-shadow: var(--pm-card-hover-shadow),
+              0 0 0 1px rgba(34, 211, 238, .12),
+              0 0 24px rgba(34, 211, 238, .12);
+}
+
+.pm-card:hover::after,
+.pm-card:focus-visible::after {
+  opacity: 1;
 }
 
 .pm-card:hover .pm-card__title,
 .pm-card:focus-visible .pm-card__title {
-  color: var(--pm-accent);
+  color: var(--pm-dive-sonar);
+}
+
+[data-md-color-scheme="default"] .pm-card:hover .pm-card__title,
+[data-md-color-scheme="default"] .pm-card:focus-visible .pm-card__title {
+  color: #0891B2; /* 海面亮卡上 sonar 对比不足,提为同系深青 */
 }
 
 .pm-card:hover .pm-card__icon,
 .pm-card:focus-visible .pm-card__icon {
-  color: var(--pm-accent);
+  color: var(--pm-dive-sonar);
+  opacity: 1;
 }
 
-/* 11.6 响应式 hero 与按钮 */
+[data-md-color-scheme="slate"] .pm-card:hover .pm-card__icon,
+[data-md-color-scheme="slate"] .pm-card:focus-visible .pm-card__icon {
+  color: var(--pm-dive-phosphor);
+}
+
+/* 11.6 响应式 hero 与按钮(窄屏:HUD 缩短,视口角框淡出) */
 @media screen and (max-width: 600px) {
   .pm-home-body {
-    padding: 0 .6rem;
+    padding: .9rem 0 1.1rem;
+  }
+
+  .pm-home-body::before {
+    inset: 0 -.6rem; /* 窄屏外扩收敛(内容 margin 16px,按钮不贴边) */
   }
 
   .pm-hero {
@@ -983,9 +1190,21 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
   .pm-btn--search {
     width: 100%;
   }
+
+  /* HUD 缩短:SONAR ▸ DEPTH 342M ▸ MOD 07/07 */
+  .pm-hero__brand::before {
+    content: "SONAR ▸ DEPTH 342M ▸ MOD 07/07";
+    font-size: .56rem;
+    letter-spacing: .16em;
+    padding: .35rem 11% .2rem;
+  }
+
+  .pm-hero__brand::after {
+    right: 3%;
+  }
 }
 
-/* 11.7 减少动态:关闭位移过渡 */
+/* 11.7 减少动态:关闭位移过渡与深海动画(洋流/光标闪烁)的静态回退 */
 @media (prefers-reduced-motion: reduce) {
   .md-typeset a.pm-btn,
   .pm-btn,
@@ -1000,6 +1219,12 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
   .pm-card:hover,
   .pm-card:focus-visible {
     transform: none;
+  }
+
+  .pm-hero::before,
+  .pm-hero__eyebrow::after,
+  .pm-hero__brand::after {
+    animation: none;
   }
 }
 
@@ -1043,52 +1268,122 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
   }
 }
 
+/* 11.9 「本站的原则」列表与 note:页身内的玻璃行(随主题,与卡片同语言) */
+[data-md-color-scheme="default"] .pm-home-body h2,
+[data-md-color-scheme="default"] .pm-home-body .admonition-title {
+  color: #0F1B2D;
+}
+
+[data-md-color-scheme="slate"] .pm-home-body h2,
+[data-md-color-scheme="slate"] .pm-home-body .admonition-title {
+  color: var(--pm-dive-ink);
+}
+
+.pm-home-body ul {
+  padding-left: 0;
+  list-style: none;
+}
+
+.pm-home-body > ul li {
+  margin: .45rem 0;
+  padding: .6rem .9rem;
+  border: 1px solid var(--pm-dive-line);
+  border-radius: 10px;
+}
+
+[data-md-color-scheme="default"] .pm-home-body > ul li {
+  background-color: rgba(255, 255, 255, .55);
+  border-color: rgba(34, 211, 238, .22);
+}
+
+[data-md-color-scheme="slate"] .pm-home-body > ul li {
+  background-color: rgba(10, 20, 40, .4);
+  border-color: rgba(148, 196, 255, .14);
+}
+
+/* 页身 note:玻璃卡片 + sonar 色条/图标(首页专属覆盖) */
+.pm-home-body .admonition,
+.pm-home-body details {
+  background-color: rgba(10, 20, 40, .4);
+  border-radius: 12px;
+}
+
+[data-md-color-scheme="default"] .pm-home-body .admonition,
+[data-md-color-scheme="default"] .pm-home-body details {
+  background-color: rgba(255, 255, 255, .55);
+  border-color: rgba(34, 211, 238, .35);
+}
+
+[data-md-color-scheme="slate"] .pm-home-body .admonition,
+[data-md-color-scheme="slate"] .pm-home-body details {
+  background-color: rgba(10, 20, 40, .4);
+  border-color: rgba(34, 211, 238, .3);
+}
+
+.pm-home-body .note > .admonition-title::before,
+.pm-home-body .note > summary::before {
+  background-color: var(--pm-dive-sonar);
+}
+
+.pm-home-body a {
+  color: #0891B2;
+}
+
+[data-md-color-scheme="slate"] .pm-home-body a {
+  color: var(--pm-dive-sonar);
+}
+
+.pm-home-body a:hover {
+  color: var(--pm-dive-phosphor);
+}
+
+[data-md-color-scheme="default"] .pm-home-body a:hover {
+  color: #0E7490;
+}
+
 /* ----------------------------------------------------------------------------
-   12. 首页 banner:「等势线地形 · Carved AIPM」(WebGL,2026-08-23 第三版,
-       取代粒子聚字版——粒子散开可读性差、与等势线同层打架)
-       WebGL fragment shader 实时渲染 domain-warped fbm 标量场;AIPM 字形纹理
-       在 shader 内把场压平成盆地——等势线字内消失、字缘堆叠成环;另取字形
-       遮罩 0.5 等值线常绘边缘轮廓(呼吸 + 指针增亮,多数时段清晰),
-       字母由地形负形 + 轮廓线显现 + 极淡 accent 洗色;3 颗环境电荷游走,
-       指针移入注入第四颗。
-       双层 canvas(--gl 场层 + --ink 标签层,仅 6 枚主题 micro 标签),
-       无 WebGL 降级为 2D 静态帧;prefers-reduced-motion 单帧;
-       实现详见 _static/js/banner.js。
+   12. 首页 banner:「深海测深场 · Carved AIPM」(WebGL,2026-08-23 第三版引擎,
+       2026-08-25 深海改版:等势线地形读作「知识海沟」的测深地形图,
+       等势线 = 水深线 = sonar 青,计曲线 = phosphor,字形 AIPM 是「知识海沟」;
+       视口四角 ASCII 折线 + 顶条 VESSEL.SYS + 生物荧光粒子流(JS ink 层);
+       domain-warped fbm 标量场 / 电荷 / 字形雕刻等契约全部不变。
        token 七色:细线/计曲线/网格/字形洗色/正文/浅淡(标签)/强调,
-       亮暗各一套;JS 只解析 hex/rgb()/rgba(),token 请勿用 hsl()/hsla()。
+       hero 恒深海 → 亮暗两套同色(「海面下永远黑暗」);JS 只解析
+       hex/rgb()/rgba(),token 请勿用 hsl()/hsla()。
    ---------------------------------------------------------------------------- */
 :root {
-  --pm-banner-line: rgba(64, 81, 181, .2);
-  --pm-banner-major: rgba(64, 81, 181, .6);
-  --pm-banner-grid: rgba(0, 0, 0, .05);
-  --pm-banner-glyph: rgba(64, 81, 181, .09);
-  --pm-banner-ink: rgba(30, 36, 54, .78);
-  --pm-banner-faint: rgba(30, 36, 54, .42);
-  --pm-banner-accent: rgba(64, 81, 181, .95);
+  --pm-banner-line: rgba(34, 211, 238, .22);     /* 细等势线:sonar 青 */
+  --pm-banner-major: rgba(165, 243, 252, .6);    /* 计曲线:phosphor */
+  --pm-banner-grid: rgba(148, 196, 255, .05);    /* 底纹发丝网格 */
+  --pm-banner-glyph: rgba(34, 211, 238, .07);    /* 字形洗色:sonar 极淡 */
+  --pm-banner-ink: rgba(230, 240, 250, .88);     /* ink-text */
+  --pm-banner-faint: rgba(126, 156, 192, .6);    /* muted */
+  --pm-banner-accent: rgba(165, 243, 252, .95);  /* phosphor 强调 */
 }
 
 [data-md-color-scheme="slate"] {
-  --pm-banner-line: rgba(142, 166, 255, .3);
-  --pm-banner-major: rgba(142, 166, 255, .78);
-  --pm-banner-grid: rgba(255, 255, 255, .06);
-  --pm-banner-glyph: rgba(142, 166, 255, .12);
-  --pm-banner-ink: rgba(232, 233, 238, .85);
-  --pm-banner-faint: rgba(232, 233, 238, .5);
-  --pm-banner-accent: rgba(142, 166, 255, .95);
+  --pm-banner-line: rgba(34, 211, 238, .22);
+  --pm-banner-major: rgba(165, 243, 252, .6);
+  --pm-banner-grid: rgba(148, 196, 255, .05);
+  --pm-banner-glyph: rgba(34, 211, 238, .07);
+  --pm-banner-ink: rgba(230, 240, 250, .88);
+  --pm-banner-faint: rgba(126, 156, 192, .6);
+  --pm-banner-accent: rgba(165, 243, 252, .95);
 }
 
-/* 12.1 容器:圆角卡片,与站点卡片语言一致(1px 描边 + 大圆角);
-   位于首页 hero(替代原 logo 位),宽度收敛到 61rem 与正文同宽 */
+/* 12.1 容器:「潜航器视口」—— trench 玻璃面板 + 发丝描边 + 大圆角;
+   位于首页 hero(替代原 logo 位),宽度收敛到 61rem 与正文同宽;
+   四角括号用 border 折角绘制(TL 顶条自含、BR ::after,克制) */
 .pm-banner {
   position: relative;
   width: 100%;
   aspect-ratio: 5 / 2;
   min-height: 210px;
   margin: .9rem 0 1.4rem;
-  border: 1px solid var(--pm-line);
-  border-radius: 18px;
+  border: 1px solid var(--pm-dive-line);
+  border-radius: 14px;
   overflow: hidden;
-  background: var(--md-default-bg-color);
+  background: rgba(10, 20, 40, .5);
   isolation: isolate;
 }
 
@@ -1110,4 +1405,55 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
   display: block;
   width: 100%;
   height: 100%;
+}
+
+/* 12.3 视口顶条:ASCII 终端框的左上折角 + VESSEL.SYS 标签 + 双 led 点 */
+.pm-banner::before {
+  content: "VESSEL.SYS";
+  position: absolute;
+  z-index: 2;
+  top: .8rem;
+  left: .9rem;
+  width: min(56%, 20rem);
+  padding: .42rem .6rem .3rem 0;
+  font-family: var(--md-code-font);
+  font-size: .58rem;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: .3em;
+  color: rgba(126, 156, 192, .9);
+  border-top: 1px solid rgba(165, 243, 252, .45);
+  border-left: 1px solid rgba(165, 243, 252, .45);
+  background-image:
+    radial-gradient(circle 2px at calc(100% - 1.3rem) 50%, rgba(165, 243, 252, .8) 99%, transparent),
+    radial-gradient(circle 2px at calc(100% - 2rem) 50%, rgba(165, 243, 252, .4) 99%, transparent);
+  background-repeat: no-repeat;
+  background-size: 100% 100%;
+  background-position: 0 0;
+  pointer-events: none;
+}
+
+/* 12.4 视口右下折角(BR 对角,与顶条左上呼应) */
+.pm-banner::after {
+  content: "";
+  position: absolute;
+  z-index: 2;
+  right: .8rem;
+  bottom: .8rem;
+  width: .85rem;
+  height: .85rem;
+  border-right: 2px solid rgba(165, 243, 252, .35);
+  border-bottom: 2px solid rgba(165, 243, 252, .35);
+  pointer-events: none;
+}
+
+@media (max-width: 640px) {
+  .pm-banner::before {
+    width: auto;
+    max-width: 62%;
+  }
+
+  .pm-banner::after {
+    display: none;
+  }
 }

--- a/docs/_static/css/extra.css
+++ b/docs/_static/css/extra.css
@@ -1177,6 +1177,12 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
     padding: 2rem 1rem 1.75rem;
   }
 
+  /* 眉题:窄屏收敛字距/字号,防整句右溢裁切(完整显示,光标块对齐) */
+  .pm-hero__eyebrow {
+    font-size: .6rem;
+    letter-spacing: .18em;
+  }
+
   .pm-hero .site-name {
     font-size: 1.6rem;
   }

--- a/docs/_static/css/extra.css
+++ b/docs/_static/css/extra.css
@@ -1313,18 +1313,22 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
        等势线 = 水深线 = sonar 青,计曲线 = phosphor,字形 AIPM 是「知识海沟」;
        视口四角 ASCII 折线 + 顶条 VESSEL.SYS + 生物荧光粒子流(JS ink 层);
        domain-warped fbm 标量场 / 电荷 / 字形雕刻等契约全部不变。
-       token 七色:细线/计曲线/网格/字形洗色/正文/浅淡(标签)/强调,
-       banner 卡内深海画不随主题(视口内自成一格)→ 亮暗两套同色;JS 只解析
-       hex/rgb()/rgba(),token 请勿用 hsl()/hsla()。
+       2026-08-25 打磨(用户定案):卡内随主题、深/浅两个风格(同构两调性)——
+       深色 = 深海(现状不动:黑蓝底 + sonar 青 + 荧光粒子);
+       浅色 = 白昼海面:浅海面底 + 青蓝等势线 + 深墨 mono 仪器 chrome,
+       白天测深图观感,禁止灰蒙。
+       token 七色(细线/计曲线/网格/字形洗色/正文/标签/强调)由 banner.js
+       解析(只支持 hex/rgb()/rgba(),请勿用 hsl()/hsla()),主题切换自动重绘;
+       :root 为浅色集,slate 块为深色集,两套各自成调,深色集一个值不许动。
    ---------------------------------------------------------------------------- */
 :root {
-  --pm-banner-line: rgba(34, 211, 238, .22);     /* 细等势线:sonar 青 */
-  --pm-banner-major: rgba(165, 243, 252, .6);    /* 计曲线:phosphor */
-  --pm-banner-grid: rgba(148, 196, 255, .05);    /* 底纹发丝网格 */
-  --pm-banner-glyph: rgba(34, 211, 238, .07);    /* 字形洗色:sonar 极淡 */
-  --pm-banner-ink: rgba(230, 240, 250, .88);     /* ink-text */
-  --pm-banner-faint: rgba(126, 156, 192, .6);    /* muted */
-  --pm-banner-accent: rgba(165, 243, 252, .95);  /* phosphor 强调 */
+  --pm-banner-line: rgba(37, 99, 235, .30);      /* 细等势线:白天测深图蓝(可见但克制) */
+  --pm-banner-major: rgba(8, 145, 178, .55);     /* 计曲线/字缘轮廓:青 */
+  --pm-banner-grid: rgba(30, 64, 175, .06);      /* 底纹发丝网格 */
+  --pm-banner-glyph: rgba(59, 130, 246, .08);    /* 字形洗色:蓝极淡 */
+  --pm-banner-ink: rgba(15, 27, 45, .88);        /* ink-text:深墨蓝 */
+  --pm-banner-faint: rgba(15, 27, 45, .88);      /* 标签:深墨蓝(浅底 mono 深字) */
+  --pm-banner-accent: rgba(14, 116, 144, .45);   /* 强调/粒子:深青 */
 }
 
 [data-md-color-scheme="slate"] {
@@ -1351,6 +1355,18 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
   overflow: hidden;
   background: rgba(10, 20, 40, .5);
   isolation: isolate;
+}
+
+/* 浅色 = 白昼海面视口:白玻璃 + 青描边 + blur(与站点浅色玻璃卡片同语言),
+   底为海面雾蓝微渐变,嵌在站点亮底上如一帧白天测深图 */
+[data-md-color-scheme="default"] .pm-banner {
+  background: linear-gradient(180deg, rgba(237, 244, 251, .82),
+                                     rgba(226, 238, 248, .88));
+  border-color: rgba(34, 211, 238, .3);
+  box-shadow: 0 1px 3px rgba(15, 27, 45, .05),
+              inset 0 1px 0 rgba(255, 255, 255, .9);
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
 }
 
 .pm-hero .pm-banner {
@@ -1399,6 +1415,15 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
   pointer-events: none;
 }
 
+/* 浅色顶条:深墨 mono 字 + 青折角/双 led(暗色 phosphor 的白天反转) */
+[data-md-color-scheme="default"] .pm-banner::before {
+  color: rgba(15, 27, 45, .88);
+  border-color: rgba(8, 145, 178, .45);
+  background-image:
+    radial-gradient(circle 2px at calc(100% - 1.3rem) 50%, rgba(8, 145, 178, .8) 99%, transparent),
+    radial-gradient(circle 2px at calc(100% - 2rem) 50%, rgba(8, 145, 178, .4) 99%, transparent);
+}
+
 /* 12.4 视口右下折角(BR 对角,与顶条左上呼应) */
 .pm-banner::after {
   content: "";
@@ -1411,6 +1436,10 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
   border-right: 2px solid rgba(165, 243, 252, .35);
   border-bottom: 2px solid rgba(165, 243, 252, .35);
   pointer-events: none;
+}
+
+[data-md-color-scheme="default"] .pm-banner::after {
+  border-color: rgba(8, 145, 178, .4);
 }
 
 @media (max-width: 640px) {

--- a/docs/_static/js/banner.js
+++ b/docs/_static/js/banner.js
@@ -13,8 +13,8 @@
 
   工程契约(全部保持):
   - 双层 canvas:--gl(WebGL 场)+ --ink(2D 标签层);无 WebGL → 2D 静态降级帧(深海色)
-  - 颜色全部读 extra.css 第 12 节 --pm-banner-* token(深海恒色,亮暗两套同值),
-    主题切换重绘
+  - 颜色全部读 extra.css 第 12 节 --pm-banner-* token(深/浅两套调性:
+    深=深海、浅=白昼海面;从 <body> 读计算样式,主题切换重绘)
   - prefers-reduced-motion → 固定相位的静态单帧(含粒子静态帧);
     IntersectionObserver 离屏停转;~30fps 节流;DPR 上限 1.5(shader 成本);
     webglcontextlost 降级、restored 自愈
@@ -75,11 +75,15 @@
       });
     }
 
-    /* —— token(extra.css 第 12 节,亮/暗两套;只解析 hex/rgb()/rgba()) —— */
+    /* —— token(extra.css 第 12 节,亮/暗两套;只解析 hex/rgb()/rgba()) ——
+       主题 attribute 挂在 <body>(Material 9.x:data-md-color-scheme),
+       token 集在 :root(浅)与 [data-md-color-scheme="slate"](深)上,
+       须从 body 读计算样式才能随主题取到对应集;
+       深/浅同值时读 html 也碰巧正确,两套调性分家后必须读 body */
     const T = {};
     const TOKENS = ["line", "major", "grid", "ink", "faint", "accent", "glyph"];
     const readTokens = () => {
-      const s = getComputedStyle(document.documentElement);
+      const s = getComputedStyle(document.body);
       for (const k of TOKENS) T[k] = parseColor(s.getPropertyValue(`--pm-banner-${k}`).trim());
     };
     /* "#rrggbb" | "rgb()" | "rgba()" → {r,g,b,a} (0-1) */
@@ -481,9 +485,9 @@ void main(){
     });
     io.observe(banner);
     RM.addEventListener("change", onRMChange);
-    // Material 切换亮/暗主题:<html> 的 data-md-color-scheme 变化
+    // Material 切换亮/暗主题:<body> 的 data-md-color-scheme 变化
     moTheme = new MutationObserver(() => { readTokens(); render(); });
-    moTheme.observe(document.documentElement, { attributes: true, attributeFilter: ["data-md-color-scheme"] });
+    moTheme.observe(document.body, { attributes: true, attributeFilter: ["data-md-color-scheme"] });
     glCanvas.addEventListener("webglcontextlost", onContextLost);
     glCanvas.addEventListener("webglcontextrestored", onContextRestored);
 

--- a/docs/_static/js/banner.js
+++ b/docs/_static/js/banner.js
@@ -1,22 +1,23 @@
 /*
-  AI-PM 首页 banner:「等势线地形 · Carved AIPM」(2026-08-23 第三版,
-  取代"粒子聚字"版——粒子散开可读性差、与等势线同层打架)
+  AI-PM 首页 banner:「深海测深场 · Carved AIPM」(2026-08-25 深海改版;
+  引擎沿用 2026-08-23 第三版等势线地形,工程契约全部不变)
 
-  视觉:一张会呼吸的科学制图等势线图——WebGL fragment shader 实时渲染
-  domain-warped fbm 标量场,3 颗环境电荷缓慢游走;中央大号 AIPM 不是画出来的
-  图层,而是"雕进"场里的盆地:字形区域在 shader 中被压平(等势线在字内消失、
-  在字形边缘密集堆叠成轮廓环),另取字形遮罩 0.5 等值线常绘一条边缘轮廓线
-  (缓慢呼吸,指针入场增亮——保证大多数时段字缘轮廓清晰),再罩一层极淡的
-  accent 洗色——字母由地形负形 + 轮廓线显现。指针移入即注入第四颗电荷,
-  等势线随手弯曲、在字缘缠绕。细等势线为墨色、每第 5 条计曲线(index contour)
-  为 accent 色,底衬极细发丝网格;2D 覆盖层只布 6 枚主题 micro 标签
-  (MODEL / RAG / METHOD / GROWTH / METRIC / TEAM)。
+  视觉(深海叙事·知识海沟):WebGL fragment shader 实时渲染 domain-warped fbm
+  标量场——读作「测深地形图」,等势线 = 水深线(sonar 青),每第 5 条计曲线
+  (index contour)= phosphor 亮线;AIPM 四字是「知识海沟」:字形区域在 shader
+  中被压平(等势线字内消失、字缘堆叠成轮廓环),再取字形遮罩 0.5 等值线常绘
+  一条边缘轮廓(缓慢呼吸 + 指针入场增亮),罩一层极淡 sonar 洗色;3 颗环境
+  电荷游走,指针移入即注入第四颗(声呐扰动)。ink 层 = 6 枚 ASCII micro
+  标签([ MODEL ] 等)+ 生物荧光像素流(极淡 phosphor 方块,缓慢右漂、微闪烁)。
+  视口顶条 VESSEL.SYS 与右下角框由 extra.css §12 伪元素绘制。
 
-  工程契约:
-  - 双层 canvas:--gl(WebGL 场)+ --ink(2D 标签层);无 WebGL → 2D 静态降级帧
-  - 颜色全部读 extra.css 第 12 节 --pm-banner-* token(亮/暗两套),主题切换重绘
-  - prefers-reduced-motion → 固定相位的静态单帧;IntersectionObserver 离屏停转;
-    ~30fps 节流;DPR 上限 1.5(shader 成本);webglcontextlost 降级、restored 自愈
+  工程契约(全部保持):
+  - 双层 canvas:--gl(WebGL 场)+ --ink(2D 标签层);无 WebGL → 2D 静态降级帧(深海色)
+  - 颜色全部读 extra.css 第 12 节 --pm-banner-* token(深海恒色,亮暗两套同值),
+    主题切换重绘
+  - prefers-reduced-motion → 固定相位的静态单帧(含粒子静态帧);
+    IntersectionObserver 离屏停转;~30fps 节流;DPR 上限 1.5(shader 成本);
+    webglcontextlost 降级、restored 自愈
   - instant 导航(mkdocs.yml navigation.instant)换 DOM 时 head 脚本不重跑:
     实例工厂 create() + 顶层 MutationObserver 盯 body 子树,新 .pm-banner
     出现即重挂、消失即卸载(停 rAF/断观察器/释放 GL),避免切回首页后空白
@@ -57,6 +58,22 @@
       { cx: 0.55, cy: 0.62, rx: 0.100, ry: 0.12, w1: 0.19, w2: 0.27, p1: 2.1, p2: 0.4, s: 0.26 },
       { cx: 0.82, cy: 0.42, rx: 0.065, ry: 0.15, w1: 0.26, w2: 0.21, p1: 4.2, p2: 2.9, s: 0.32 },
     ];
+
+    /* 生物荧光像素流:确定性伪随机方块(归一化锚点 + 尺寸/漂速/振幅/相位),
+       极淡 phosphor;相位由 t 驱动 → RM/离屏自动落为静态单帧 */
+    const PS = [];
+    const PS_COUNT = 36;
+    for (let i = 0; i < PS_COUNT; i++) {
+      const fr = (n) => (i * n) % 1;
+      PS.push({
+        fx: fr(0.618034),
+        fy: 0.06 + fr(0.754878) * 0.88,
+        s: 1.2 + fr(0.414214) * 1.2,
+        sp: 0.004 + fr(0.271828) * 0.008,
+        amp: 0.008 + fr(0.172345) * 0.02,
+        ph: i * 2.3999,
+      });
+    }
 
     /* —— token(extra.css 第 12 节,亮/暗两套;只解析 hex/rgb()/rgba()) —— */
     const T = {};
@@ -326,13 +343,28 @@ void main(){
         ink.moveTo(x, y - 4); ink.lineTo(x, y + 4);
         ink.stroke();
         ink.fillStyle = css(T.faint);
-        ink.fillText(l.t, x + 8, y + 0.5);
+        ink.fillText(`[ ${l.t} ]`, x + 8, y + 0.5); // ASCII 方括号,终端风
+      }
+    };
+
+    /* 生物荧光像素流:整数网格方块(原子像素),缓慢右漂 + 微闪烁;
+       窄屏减量;RM/离屏时只有静态单帧(相位固定) */
+    const drawParticles = (t) => {
+      const n = Math.max(6, Math.round((W * H) / 14000) * (W < 560 ? 0.5 : 1));
+      for (let i = 0; i < Math.min(n, PS_COUNT); i++) {
+        const P = PS[i];
+        const x = Math.round(((P.fx + t * P.sp) % 1) * W);
+        const y = Math.round((P.fy + Math.sin(t * 0.35 + P.ph) * P.amp) * H);
+        const flick = 0.55 + 0.45 * Math.sin(t * 1.4 + P.ph * 3.1);
+        ink.fillStyle = css(T.accent, (0.05 + 0.14 * ((i % 5) / 5)) * flick);
+        ink.fillRect(x, y, P.s, P.s);
       }
     };
 
     const drawInk = (t) => {
       ink.clearRect(0, 0, W, H);
       drawLabels(t);
+      drawParticles(t);
     };
 
     /* 无 WebGL 降级:静态网格 + 光斑 + 描边大字 + 标签单帧 */
@@ -368,6 +400,7 @@ void main(){
       ink.lineWidth = 1.2;
       ink.strokeText("AIPM", W / 2, H / 2);
       drawLabels(18);
+      drawParticles(18);
     };
 
     /* —— 指针状态(平滑追踪 + 强度缓入出) —— */

--- a/docs/_static/js/banner.js
+++ b/docs/_static/js/banner.js
@@ -45,7 +45,7 @@
     const LABELS = [
       { t: "MODEL",  fx: 0.07, fy: 0.20 },
       { t: "RAG",    fx: 0.09, fy: 0.82 },
-      { t: "METHOD", fx: 0.32, fy: 0.10 },
+      { t: "METHOD", fx: 0.32, fy: 0.20 },
       { t: "GROWTH", fx: 0.34, fy: 0.90 },
       { t: "METRIC", fx: 0.87, fy: 0.16 },
       { t: "TEAM",   fx: 0.91, fy: 0.80 },

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -221,10 +221,10 @@ extra:
   #   property: YOUR-GA-ID
 
 extra_javascript:
-  - '_static/js/banner.js?v=7'
+  - '_static/js/banner.js?v=8'
   - '_static/js/header-line.js?v=1'
 extra_css:
-  - '_static/css/extra.css?v=29'
+  - '_static/css/extra.css?v=30'
 
 # Extensions
 markdown_extensions:


### PR DESCRIPTION
## 说明
用户审查用 PR(dev 未合并)。重构首页样式的完整工作:背景与站点一致(亮/暗两风格),banner 为「潜航器视口」(深海画 + VESSEL.SYS + ASCII 芯片 + HUD),玻璃卡片网格,站内全局 chrome 零改动,主题子模块零改动。

## 分支构成(8 commit,均为小步)
- style(home): 首页深海玻璃重构(hero 视口框/HUD/玻璃卡片)
- feat(home): banner 深海视觉(荧光像素流 + ASCII 标签)
- chore(config): bump extra.css v30 / banner.js v8
- fix(home): METHOD 芯片错位
- fix(home): 移动端 eyebrow 裁切
- style(home): 背景对齐站点(去大色带/洋流/甲板面板/闪烁光标)
- fix(home): 浅色「白昼海面」重制
- fix(home): banner token 改从 body 读(Material 的 scheme attribute 挂 body)

## 门禁
git diff --check / mkdocs build / check-characters / check-upstream-remnants 全绿(boss 复跑确认);视觉验收:暗/亮/移动端截图通过。

## 审查提示
浅色 = 白昼测深图风格;深色 = 深海;卡内随主题。本 PR 仅审查用,合并由用户确认后执行。