### PR TITLE
dev: 发布搜索修复批次(中文分词/专名二元词/锚点)与 widget 流式/PWA 修复

### DIFF
--- a/docs/_static/js/chat-widget.js
+++ b/docs/_static/js/chat-widget.js
@@ -243,6 +243,7 @@
      ================================================================ */
   const history = [];       // [{role, content}] 内存态,与 localStorage 同步
   let streaming = null;     // { ac: AbortController }
+  let turnSeq = 0;          // turn 级令牌:runTurn 捕获自增值;清空/新 turn 使在飞 turn 失效
   let attachments = [];     // [{name, size, type}] 纯 UI 附件
 
   const persist = () => {
@@ -507,8 +508,10 @@
   /* 一轮问答:用户消息已入 history(由 postUser / regenerate 负责),
      这里只负责 AI 气泡与流式接收 */
   const runTurn = async (message) => {
+    const myTurn = ++turnSeq;             // 捕获本 turn 令牌:清空/新 turn 后本 turn 失效
     const ctx = { acc: "", sourceList: [], sourceSeen: new Set(), requestId: null };
     const t = addAiBubble();
+    let finished = false;                 // 收尾只执行一次(done/error/流自然结束)
     setThinking(t.md);
     setStreamingUI(true);
     clearEmpty();
@@ -520,15 +523,21 @@
       history: history.slice(0, -1).slice(-HISTORY_SEND), // 最近轮次(不含本条)
     };
 
+    /* 收尾统一出口:失效 turn(清空/新 turn 后)不再写 history/DOM,
+       避免"只有回答、没有对应问题"的孤儿历史;但流式状态必须复位,
+       否则清空后发送按钮仍卡在"停止生成" */
     const finish = (assistantText) => {
-      if (assistantText) {
+      if (finished) return;
+      finished = true;
+      const stale = myTurn !== turnSeq;
+      if (!stale && assistantText) {
         history.push({ role: "assistant", content: assistantText });
         t.wrap.setAttribute("data-hidx", history.length - 1);
         persist();
       }
       setStreamingUI(false);
       updateSendState();
-      showActions(t, assistantText || ctx.acc || "");
+      if (!stale) showActions(t, assistantText || ctx.acc || "");
     };
 
     try {
@@ -597,6 +606,13 @@
         feed(decoder.decode(value, { stream: true }));
       }
       feed(decoder.decode());
+      /* 流自然结束但未收到 done/error 帧:补收尾,否则 streaming 永不复位,
+         发送按钮永远停在"停止生成";finished 标志保证 done 后的正常收尾
+         不重复执行 */
+      if (!finished) {
+        t.md.innerHTML = ctx.acc ? mdLite(ctx.acc) : "";
+        finish(ctx.acc);
+      }
     } catch (err) {
       if (err && err.name === "AbortError") {
         t.bubble.classList.add("is-error");
@@ -845,6 +861,7 @@
   els.close.addEventListener("click", close);
 
   els.clear.addEventListener("click", () => {
+    turnSeq++;                            // 在飞 turn 失效:其 finish()/写回成为 no-op
     history.length = 0;
     persist();
     els.msgs.textContent = "";

--- a/docs/service-worker.js
+++ b/docs/service-worker.js
@@ -1,3 +1,97 @@
-this.addEventListener('fetch', function (event) {
-  //
+/*
+  AI-PM 静态站点 Service Worker —— 最小缓存策略(2026-08-25)
+
+  主题 base.html 注册本文件(scope "/"),此前为空 fetch 监听,PWA 名存实亡。
+  现按资源易变性分两类缓存:
+
+  - 静态资源(_static/、assets/、根层 favicon/manifest、带 ?v= 版本参数的
+    JS/CSS 等)→ cache-first:命中缓存直接返回,未命中走网络并回填。
+  - 易变内容(页面文档 HTML、search/search_index.json、sitemap.xml 等)→
+    network-first:先走网络保证内容新鲜(network-first 防陈旧),网络失败时
+    兜底用缓存(防离线白屏),成功后回填缓存。
+
+  保守原则:
+  - 只拦截同源 GET;非 GET / 跨源(如 Google Fonts、widget API)一律放行,
+    交给浏览器默认处理,不缓存。
+  - 仅缓存 HTTP ok(2xx,排除 206 部分内容)响应;失败响应不落缓存。
+  - 响应体 clone 后入缓存,不影响原响应流。
+  - 淘汰:简单 FIFO 上限(每个缓存 ≤ 100 项,超限删最旧)。轻量站点,
+    不做 install 预缓存全站,按需缓存即可。
+*/
+"use strict";
+
+const CACHE_STATIC = "aipm-static-v1";
+const CACHE_DYNAMIC = "aipm-dynamic-v1";
+const CACHE_MAX = 100; // 每个缓存的条目上限(FIFO 淘汰)
+
+/* 静态资源:站内构建产物目录 / 版本化参数(?v=N)/ 常见静态扩展名 / 根层站点文件 */
+const STATIC_EXT_RE =
+  /\.(?:css|js|mjs|woff2?|ttf|otf|eot|svgz?|png|jpe?g|gif|webp|avif|ico)(?:$|[?#])/i;
+const STATIC_PATH_RE = [
+  /^\/_static\//,
+  /^\/assets\//,
+  /^\/(?:manifest\.webmanifest|favicon(?:_\d+x\d+)?\.[a-z0-9]+|robots\.txt)$/i,
+];
+
+/* 易变内容:搜索索引与站点地图随内容重建,页面文档单独按 navigate 判定 */
+const DYNAMIC_RE = /^\/search\//;
+const siteMapRe = /^\/sitemap\.xml(?:\.gz)?$/;
+
+const kindOf = (url) => {
+  if (DYNAMIC_RE.test(url.pathname) || siteMapRe.test(url.pathname)) return "dynamic";
+  if (STATIC_EXT_RE.test(url.href) || /\?v=\d+/.test(url.search)) return "static";
+  for (const re of STATIC_PATH_RE) if (re.test(url.pathname)) return "static";
+  return null; // 其余(含未知路径)不拦截,交给浏览器默认处理
+};
+
+/* 入缓存 + FIFO 淘汰(Cache API 的 keys() 在 Chrome/Firefox 按插入序返回,
+   删最旧即删头部);配额满等异常静默降级为不缓存 */
+const putCache = async (cache, req, res) => {
+  try {
+    await cache.put(req, res.clone());
+    const keys = await cache.keys();
+    while (keys.length > CACHE_MAX) {
+      await cache.delete(keys[0]);
+      keys.shift();
+    }
+  } catch (e) {
+    /* 缓存写入失败不影响本次响应 */
+  }
+};
+
+const cacheFirst = async (req, cacheName) => {
+  const cache = await caches.open(cacheName);
+  const hit = await cache.match(req);
+  if (hit) return hit;
+  const res = await fetch(req);
+  if (res && res.ok && res.status !== 206) putCache(cache, req, res);
+  return res;
+};
+
+const networkFirst = async (req, cacheName) => {
+  const cache = await caches.open(cacheName);
+  try {
+    const res = await fetch(req);
+    if (res && res.ok && res.status !== 206) putCache(cache, req, res);
+    return res;
+  } catch (err) {
+    const hit = await cache.match(req);
+    if (hit) return hit;
+    throw err;
+  }
+};
+
+self.addEventListener("fetch", (event) => {
+  const req = event.request;
+  if (req.method !== "GET") return; // 只缓存 GET(其他方法直接放行)
+  const url = new URL(req.url);
+  if (url.origin !== self.location.origin) return; // 只处理同源
+  const kind = kindOf(url);
+  if (!kind) return;
+  const pageDoc = req.mode === "navigate" || req.destination === "document";
+  event.respondWith(
+    kind === "dynamic" || pageDoc
+      ? networkFirst(req, CACHE_DYNAMIC)
+      : cacheFirst(req, CACHE_STATIC)
+  );
 });

--- a/hooks/on_env.py
+++ b/hooks/on_env.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import re
 
@@ -43,10 +44,37 @@ def _chunk_sentences(text):
             chunks.append(s)
     return chunks
 
+_jieba = None
+_jieba_missing_warned = False
+
+def _segment_text(text):
+    """jieba 预分词:词间插空格,使索引侧按 /[\\s\\-]/ 切词后 key=真实词
+    (否则中文整段 text 是单个 key,查询侧 segment() 贪心退化到单字,如"会计"错配"会")。
+
+    jieba 惰性 import + 缺依赖优雅降级:返回 None 时调用方跳过该 doc 分词,构建不炸。
+    """
+    global _jieba, _jieba_missing_warned
+    if _jieba is None:
+        try:
+            import jieba
+            _jieba = jieba
+        except ImportError:
+            if not _jieba_missing_warned:
+                logging.getLogger("mkdocs").warning(
+                    "search-jieba: jieba 未安装,中文搜索索引不做预分词(多字查询可能退化为单字)"
+                )
+                _jieba_missing_warned = True
+            return None
+    return " ".join(_jieba.cut(text))
+
 def on_post_build(config, **kwargs):
     # 内置 search 插件把整页文本抹成一行(无 HTML 标签),Material 搜索 worker
     # 的摘要机制按块级标签切块,于是整页=一块,命中词所在"块"=全文。
     # 这里把 text 按句子切成 <p> 块,恢复「命中句摘要」(最多两句)。
+    #
+    # 另外:worker 索引侧按 /[\s\-]/ 切词,中文整段 text 是单个索引 key,查询侧
+    # segment() 对精确 key 贪心最长匹配,"会计"无精确 key 会退化到单字"会"导致
+    # 前缀通配全错配。修复:先用 jieba 预分词、词间插空格,再走句子切块。
     path = os.path.join(config["site_dir"], "search", "search_index.json")
     if not os.path.exists(path):
         return
@@ -58,8 +86,16 @@ def on_post_build(config, **kwargs):
         # 而不是 "in",避免正文含代码示例("<p>")的文档被误判为已处理
         if not text or text.startswith("<p>"):
             continue
-        chunks = _chunk_sentences(text)
+        # 1) jieba 预分词(词间插空格),让索引 key = 真实词
+        segmented = _segment_text(text)
+        if segmented is None:
+            continue
+        # 2) 再按句子包 <p> 块,恢复命中句摘要
+        chunks = _chunk_sentences(segmented)
         if len(chunks) > 1:
             doc["text"] = "<p>" + "</p><p>".join(chunks) + "</p>"
+        else:
+            # 无句子边界的单块也须写入分词结果,否则该 doc 仍是整段单 key
+            doc["text"] = segmented
     with open(path, "w", encoding="utf-8") as f:
         json.dump(index, f, ensure_ascii=False)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -215,7 +215,7 @@ extra:
   # enabled 关闭后不再注入;version 缓存击穿号,改了资源后 +1 即可
   chat_agent:
     enabled: true
-    version: 8
+    version: 9
   # analytics:  # TODO: 需要访问统计时取消注释并填写自己的 ID
   #   provider: google
   #   property: YOUR-GA-ID

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "markdown==3.9",
     "python-markdown-document-offsets-injection-extension==0.5.16",
     "mkdocs-toggle-sidebar-plugin==0.0.8",
+    "jieba==0.42.1",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -8,6 +8,7 @@ version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },
+    { name = "jieba" },
     { name = "markdown" },
     { name = "mkdocs" },
     { name = "mkdocs-toggle-sidebar-plugin" },
@@ -19,6 +20,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4" },
+    { name = "jieba", specifier = "==0.42.1" },
     { name = "markdown", specifier = "==3.9" },
     { name = "mkdocs", specifier = "==1.6.1" },
     { name = "mkdocs-toggle-sidebar-plugin", specifier = "==0.0.8" },
@@ -75,6 +77,12 @@ sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
 ]
+
+[[package]]
+name = "jieba"
+version = "0.42.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c6/cb/18eeb235f833b726522d7ebed54f2278ce28ba9438e3135ab0278d9792a2/jieba-0.42.1.tar.gz", hash = "sha256:055ca12f62674fafed09427f176506079bc135638a14e23e25be909131928db2", size = 19214172, upload-time = "2020-01-20T14:27:23.5Z" }
 
 [[package]]
 name = "jinja2"


### PR DESCRIPTION
dev→main 发布(自动跟进 dev,含 gitlink 重指后将更新的提交)。

## 内容(自上次发布以来)
- **搜索修复(search-jieba)**:hooks/on_env.py jieba 预分词,修复站内中文搜索退化单字("会计"曾全部以"会"命中);依赖 jieba==0.42.1(CI uv sync --frozen 自动覆盖)。
- **agent-server 子模块指针**(gitlink)→ 检索/并发修复 commit(扫描项:专名二元词保护、锚点百分号解码、mergeSections 排序、runAgent 槽释放、BODY_LIMIT 按字节;详见 aipm-agent-server PR #6)。
- **widget 修复(widget-stream-fix)**:chat-widget 流式卡死/清空竞态、service-worker 真实缓存、chat_agent.version 8→9。
- **门禁**:各批次 git diff --check / uv run mkdocs build -q / check-characters / check-upstream-remnants 全部 PASSED;dev 与 origin/dev 对齐,浏览器端搜索经真实 worker+真实索引端到端验证。

## 合并方式
普通 merge(禁 squash,仓库既有策略)。