### PR TITLE
fix(ci): 修复 build.yml 因 secrets 用于 if: 条件导致的 workflow 失效

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,10 @@ jobs:
     # 仅部署 job 需要写权限;构建 job 一律 contents: read
     permissions:
       contents: write
+    # secrets context 不允许用在 if: 条件里(会 invalidate 整个 workflow),
+    # 故先映射到 job 级 env,再用 env.INDEXNOW_KEY 判空。
+    env:
+      INDEXNOW_KEY: ${{ secrets.INDEXNOW_KEY }}
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
       - name: Download site artifact
@@ -92,8 +96,8 @@ jobs:
           name: site
           path: ./site
       - name: Write IndexNow key file
-        if: secrets.INDEXNOW_KEY != ''
-        run: echo "${{ secrets.INDEXNOW_KEY }}" > site/${{ secrets.INDEXNOW_KEY }}.txt
+        if: ${{ env.INDEXNOW_KEY != '' }}
+        run: echo "${{ env.INDEXNOW_KEY }}" > site/${{ env.INDEXNOW_KEY }}.txt
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4
         with:
@@ -101,5 +105,5 @@ jobs:
           publish_dir: ./site
           force_orphan: true
       - name: Submit IndexNow
-        if: secrets.INDEXNOW_KEY != ''
-        run: python3 scripts/post-deploy/indexnow.py --key "${{ secrets.INDEXNOW_KEY }}"
+        if: ${{ env.INDEXNOW_KEY != '' }}
+        run: python3 scripts/post-deploy/indexnow.py --key "${{ env.INDEXNOW_KEY }}"


### PR DESCRIPTION
## 根因

main 上 run 33038596049(PR #40 合并后)直接失败,零 job 启动,提示 workflow file issue。

`build.yml` 第 95/104 行用了 `if: secrets.INDEXNOW_KEY != ''`。**GitHub Actions 的 secrets context 不允许出现在 `if:` 条件里**(仅 `run:`/`env`/`with` 可用),会报 `Unrecognized named-value: 'secrets'`,整个 workflow 校验失败、job 不启动。

旧 main 的 build.yml 没有这两个 IndexNow 步骤(由 dev 侧 aipm-wt-build/ci 引入),PR #40 是它们首次上 main,故此前从未暴露。

## 修复

将 secret 映射到 deploy job 级 `env.INDEXNOW_KEY`,step `if:` 改为判断 `env.INDEXNOW_KEY != ''`(env context 在 step if 允许)。`run:` 也改用 ${{ env.INDEXNOW_KEY }} 保持一致。

已验证:
- YAML 解析 OK
- 全 .github/workflows/ 无残留 `if: secrets`
- 行为不变:key 未配时两步仍跳过;配了则写 `site/<key>.txt` → 部署 → 提交 IndexNow