### PR TITLE
fix(scripts): indexnow 提交加重试,消除 gh-pages 传播时差导致的 CI 失败

### DIFF
--- a/scripts/post-deploy/indexnow.py
+++ b/scripts/post-deploy/indexnow.py
@@ -19,6 +19,7 @@ import argparse
 import json
 import os
 import sys
+import time
 import urllib.error
 import urllib.request
 import xml.etree.ElementTree as ET
@@ -26,6 +27,11 @@ from urllib.parse import urlparse
 
 INDEXNOW_ENDPOINT = "https://api.indexnow.org/indexnow"
 TIMEOUT_SECONDS = 30
+
+# gh-pages 部署传播有几十秒时延,提交时 IndexNow 校验 key 文件可能短暂返回
+# 403/SiteVerificationNotCompleted;此外还有限流(429)与服务端抖动(5xx)。
+# 这些属于可重试的瞬时错误,按以下间隔重试,最坏 ~2.7 分钟。
+RETRY_SLEEPS = [20, 20, 30, 30, 60]
 
 
 def parse_args(argv):
@@ -98,6 +104,30 @@ def submit(payload):
         return resp.status
 
 
+def classify_error(e):
+    """返回 (is_transient, error_text)。
+
+    is_transient=True 表示值得重试的瞬时错误(部署传播 / 限流 / 5xx / 网络抖动);
+    其余 HTTP 错误(如 key 错误、格式错误)是永久性的,直接失败。
+    error_text 已包含响应体(若有),可直接打印。
+    """
+    if isinstance(e, urllib.error.URLError):
+        return True, "ERROR: request to IndexNow failed: %s" % e.reason
+    if isinstance(e, urllib.error.HTTPError):
+        try:
+            body = e.read().decode("utf-8", "replace")
+        except Exception:
+            body = ""
+        text = "ERROR: IndexNow returned HTTP %d: %s" % (e.code, e.reason)
+        if body:
+            text += "\n%s" % body
+        transient = e.code in (429, 502, 503, 504) or (
+            e.code == 403 and "SiteVerificationNotCompleted" in body
+        )
+        return transient, text
+    return False, "ERROR: unexpected error: %r" % e
+
+
 def main(argv=None):
     args = parse_args(argv)
 
@@ -139,26 +169,24 @@ def main(argv=None):
         "Submitting %d URLs from %s to IndexNow (host=%s)..."
         % (len(urls), args.sitemap, host)
     )
-    try:
-        status = submit(payload)
-    except urllib.error.HTTPError as e:
-        body = e.read().decode("utf-8", "replace")
-        print(
-            "ERROR: IndexNow returned HTTP %d: %s" % (e.code, e.reason),
-            file=sys.stderr,
-        )
-        if body:
-            print(body, file=sys.stderr)
-        return 1
-    except urllib.error.URLError as e:
-        print(
-            "ERROR: request to IndexNow failed: %s" % e.reason,
-            file=sys.stderr,
-        )
-        return 1
-
-    print("OK: submitted %d URLs (HTTP %d)" % (len(urls), status))
-    return 0
+    for attempt in range(len(RETRY_SLEEPS) + 1):
+        try:
+            status = submit(payload)
+            print("OK: submitted %d URLs (HTTP %d)" % (len(urls), status))
+            return 0
+        except (urllib.error.HTTPError, urllib.error.URLError) as e:
+            transient, text = classify_error(e)
+            if attempt < len(RETRY_SLEEPS) and transient:
+                delay = RETRY_SLEEPS[attempt]
+                print(
+                    "Transient failure (attempt %d/%d), retrying in %ds..."
+                    % (attempt + 1, len(RETRY_SLEEPS) + 1, delay),
+                    file=sys.stderr,
+                )
+                time.sleep(delay)
+                continue
+            print(text, file=sys.stderr)
+            return 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 背景

main 上 run 33039360956(PR #42 合并后)Build job 成功,但 **Submit IndexNow 步骤失败**:

```
ERROR: IndexNow returned HTTP 403: Forbidden
{"errorCode":"SiteVerificationNotCompleted","message":"Site Verification is not completed..."}
```

根因:deploy 完成到 GitHub Pages 全边缘传播有几十秒时延,Submit 步骤紧随 deploy 运行,IndexNow 校验 `https://aipm.ac/<key>.txt` 时文件还没上线 → 403。key 文件现已上线(curl 200 + 内容匹配),纯时序问题。

## 修复

`scripts/post-deploy/indexnow.py` 加重试:
- 新增 `RETRY_SLEEPS=[20,20,30,30,60]`(最坏 ~2.7 分钟,deploy job timeout 10min 内)
- `classify_error()` 区分可重试(403-SiteVerificationNotCompleted / 429 / 502-504 / 网络抖动)与永久错误(其他 4xx 直接失败)
- `main()` 提交改为循环重试;退出码语义不变(0 成功 / 1 网络或 HTTP 失败 / 2 用法或数据错误)

## 验证

本地实测真实提交:第 1 次瞬时失败 → 20s 后重试 → **HTTP 200,339 URL 全部提交成功**(IndexNow 已激活)。
门禁:py_compile / mkdocs build / diff-check / check-characters / check-upstream-remnants 全过。