### PR TITLE
fix(home): iOS Safari 首页 banner 水印修复(+ 仓库改名引用同步)

### DIFF
--- a/docs/_static/css/extra.css
+++ b/docs/_static/css/extra.css
@@ -1376,8 +1376,9 @@ div.md-typeset__scrollwrap:has(table[data-review-enabled]) {
   border-color: rgba(34, 211, 238, .3);
   box-shadow: 0 1px 3px rgba(15, 27, 45, .05),
               inset 0 1px 0 rgba(255, 255, 255, .9);
-  -webkit-backdrop-filter: blur(10px);
-  backdrop-filter: blur(10px);
+  /* 不加 backdrop-filter:iOS Safari 会把含子 canvas 的元素打成合成组,
+     WebGL 直通 alpha 被丢掉,视口只剩空心 AIPM 字缘(桌面 Chromium 无此问题)。
+     底已是不透明渐变,blur 也看不到背后内容。 */
 }
 
 .pm-hero .pm-banner {

--- a/docs/_static/js/banner.js
+++ b/docs/_static/js/banner.js
@@ -15,6 +15,9 @@
   - 双层 canvas:--gl(WebGL 场)+ --ink(2D 标签层);无 WebGL → 2D 静态降级帧(深海色)
   - 颜色全部读 extra.css 第 12 节 --pm-banner-* token(深/浅两套调性:
     深=深海、浅=白昼海面;从 <body> 读计算样式,主题切换重绘)
+  - WebGL 预乘 alpha(premultipliedAlpha:true + shader 输出 rgb*a):
+    iOS/iPadOS Safari 把 straight-alpha 画布按预乘合成,glyph 洗色(α≈.08)
+    与细等势线会被丢光,只剩空心字缘——桌面 Edge/Chrome 无此问题
   - prefers-reduced-motion → 固定相位的静态单帧(含粒子静态帧);
     IntersectionObserver 离屏停转;~30fps 节流;DPR 上限 1.5(shader 成本);
     webglcontextlost 降级、restored 自愈
@@ -219,7 +222,10 @@ void main(){
   alpha = max(alpha, oline * u_major.a * 1.3);
 
   alpha += (hash(gl_FragCoord.xy + fract(t)*7.0) - 0.5) * 0.02; /* 抖动去色带 */
-  gl_FragColor = vec4(col, clamp(alpha, 0.0, 1.0));
+  /* 预乘输出:与 getContext({premultipliedAlpha:true}) 配对。
+     iOS Safari 对 straight alpha 会丢掉低 α 的洗色/细线。 */
+  float a = clamp(alpha, 0.0, 1.0);
+  gl_FragColor = vec4(col * a, a);
 }`;
 
     let gl = null, prog = null, U = {}, glyphTex = null;
@@ -257,10 +263,12 @@ void main(){
     };
 
     const initGL = () => {
-      gl = glCanvas.getContext("webgl", {
-        alpha: true, premultipliedAlpha: false, antialias: true,
+      const glOpts = {
+        alpha: true, premultipliedAlpha: true, antialias: true,
         depth: false, stencil: false, powerPreference: "low-power",
-      }) || glCanvas.getContext("experimental-webgl");
+      };
+      gl = glCanvas.getContext("webgl", glOpts)
+        || glCanvas.getContext("experimental-webgl", glOpts);
       if (!gl) return false;
       gl.getExtension("OES_standard_derivatives");
       const compile = (type, src) => {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -478,11 +478,11 @@ extra:
 extra_javascript:
   - '_static/js/mathjax.js?v=2'
   - 'https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js'
-  - '_static/js/banner.js?v=9'
+  - '_static/js/banner.js?v=10'
   - '_static/js/header-line.js?v=1'
   - '_static/js/umami.js?v=1'
 extra_css:
-  - '_static/css/extra.css?v=32'
+  - '_static/css/extra.css?v=33'
 
 # Extensions
 markdown_extensions:


### PR DESCRIPTION
## 内容

1. **`dc69a85`** chore(repo):仓库改名 aipm→AIPM 引用同步(13 文件,已在 origin/dev)
2. **`fd68084` + `5acda51`** fix(home):iOS Safari 首页 banner 水印显示修复(merge `fix/ios-home-render`)

> 注:因 main 落后于 dev,本 PR 同时携带改名提交;**改名与 PR #44(迁移)有重叠,无冲突**,合并顺序无关。

## 影响

- 首页 banner 在 iOS Safari 正常显示(水印 wash 不再被裁掉)
- 仓库引用统一为 `AI-PM-Wiki/AIPM`
