### PR TITLE
fix: restore Hypothesis highlight assets

### DIFF
--- a/docs/_static/js/hypothesis.js
+++ b/docs/_static/js/hypothesis.js
@@ -1,7 +1,7 @@
 /*
  * Hypothesis 侧栏样式控制器。
- * 官方客户端由 mkdocs.yml 直接常驻加载；本脚本只处理 open shadow root 内的视觉覆盖，
- * 并在 instant 导航后重新确认侧栏样式仍然存在。
+ * 官方客户端由 mkdocs.yml 直接常驻加载；本脚本保存其动态注入的样式资源，
+ * 在 instant 导航后恢复高亮样式，并处理 open shadow root 内的侧栏视觉覆盖。
  */
 (function () {
   "use strict";
@@ -29,6 +29,9 @@
 
   if (!state) {
     state = {
+      assetTemplates: [],
+      observer: null,
+      restoreScheduled: false,
       sidebarObserver: null,
       sidebarRoot: null,
       sidebarRootObserver: null,
@@ -36,6 +39,91 @@
       subscribed: false
     };
     window[STATE_KEY] = state;
+  } else {
+    // 更新脚本时保留旧页面中的共享状态，避免 instant 导航期间丢失监听器。
+    state.assetTemplates = state.assetTemplates || [];
+    state.observer = state.observer || null;
+    state.restoreScheduled = Boolean(state.restoreScheduled);
+  }
+
+  function rememberVendorAssets() {
+    var assets = Array.from(document.querySelectorAll("[data-hypothesis-asset]"))
+      .filter(function (node) {
+        return node.tagName !== "SCRIPT";
+      })
+      .map(function (node) {
+        return {
+          key: [node.tagName, node.type, node.rel, node.href, node.src].join("|"),
+          html: node.outerHTML
+        };
+      });
+    if (assets.length) {
+      state.assetTemplates = assets;
+    }
+  }
+
+  function restoreVendorAssets() {
+    if (!state.assetTemplates.length) {
+      return;
+    }
+
+    var existing = new Set(
+      Array.from(document.querySelectorAll("[data-hypothesis-asset]"))
+        .filter(function (node) {
+          return node.tagName !== "SCRIPT";
+        })
+        .map(function (node) {
+          return [node.tagName, node.type, node.rel, node.href, node.src].join(
+            "|"
+          );
+        })
+    );
+    state.assetTemplates.forEach(function (asset) {
+      if (existing.has(asset.key)) {
+        return;
+      }
+      var template = document.createElement("template");
+      template.innerHTML = asset.html;
+      document.head.appendChild(template.content.firstElementChild);
+      existing.add(asset.key);
+    });
+  }
+
+  function scheduleRestore() {
+    if (state.restoreScheduled) {
+      return;
+    }
+    state.restoreScheduled = true;
+    window.setTimeout(function () {
+      state.restoreScheduled = false;
+      restoreVendorAssets();
+      scheduleSidebarStyle();
+    }, 0);
+  }
+
+  function observeNavigationDom() {
+    if (
+      typeof MutationObserver === "undefined" ||
+      !document.head ||
+      state.observer
+    ) {
+      return;
+    }
+    state.observer = new MutationObserver(function (mutations) {
+      var removedAsset = mutations.some(function (mutation) {
+        return Array.from(mutation.removedNodes).some(function (node) {
+          return (
+            node.nodeType === 1 &&
+            (node.matches("[data-hypothesis-asset]") ||
+              node.querySelector("[data-hypothesis-asset]"))
+          );
+        });
+      });
+      if (removedAsset) {
+        scheduleRestore();
+      }
+    });
+    state.observer.observe(document.head, { childList: true, subtree: true });
   }
 
   function installSidebarStyle() {
@@ -131,13 +219,16 @@
     });
   }
 
+  rememberVendorAssets();
+  observeNavigationDom();
   observeSidebarDom();
   scheduleSidebarStyle();
 
   if (!state.subscribed && typeof document$ !== "undefined") {
     state.subscribed = true;
     document$.subscribe(function () {
-      // Material 完成页面替换后，重新确认官方侧栏样式仍已安装。
+      // Material 完成页面替换后，恢复被 head 更新移除的官方样式资源。
+      scheduleRestore();
       scheduleSidebarStyle();
     });
   }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -543,7 +543,7 @@ extra_javascript:
   - '_static/js/umami.js?v=1'
   - '_static/js/mermaid-zoom.js?v=3'
   - 'https://hypothes.is/embed.js'
-  - '_static/js/hypothesis.js?v=8'
+  - '_static/js/hypothesis.js?v=9'
 extra_css:
   - '_static/css/extra.css?v=35'
   - '_static/css/mermaid-zoom.css?v=3'

--- a/test/test_hypothesis.py
+++ b/test/test_hypothesis.py
@@ -23,17 +23,27 @@ class TestHypothesisScripts(unittest.TestCase):
     def test_config_loads_vendor_before_local_controller(self):
         self.assertEqual(self.config.count("https://hypothes.is/embed.js"), 1)
         entries = re.findall(r"_static/js/hypothesis\.js\?v=\d+", self.config)
-        self.assertEqual(entries, ["_static/js/hypothesis.js?v=8"])
+        self.assertEqual(entries, ["_static/js/hypothesis.js?v=9"])
         self.assertLess(
             self.config.index("https://hypothes.is/embed.js"),
-            self.config.index("_static/js/hypothesis.js?v=8"),
+            self.config.index("_static/js/hypothesis.js?v=9"),
         )
 
     def test_controller_does_not_create_vendor_script(self):
         self.assertNotIn("https://hypothes.is/embed.js", self.hypothesis)
         self.assertNotIn('document.createElement("script")', self.hypothesis)
         self.assertNotIn("loadHypothesis", self.hypothesis)
-        self.assertNotIn("restoreVendorAssets", self.hypothesis)
+
+    def test_controller_restores_vendor_styles_after_instant_navigation(self):
+        self.assertIn("function rememberVendorAssets()", self.hypothesis)
+        self.assertIn("function restoreVendorAssets()", self.hypothesis)
+        self.assertIn("state.observer = new MutationObserver", self.hypothesis)
+        self.assertIn('node.matches("[data-hypothesis-asset]")', self.hypothesis)
+        self.assertIn(
+            "document.head.appendChild(template.content.firstElementChild);",
+            self.hypothesis,
+        )
+        self.assertIn('return node.tagName !== "SCRIPT";', self.hypothesis)
 
     def test_controller_keeps_one_style_controller_and_sidebar_observer(self):
         self.assertIn('var STATE_KEY = "__aipm_hypothesis_style";', self.hypothesis)


### PR DESCRIPTION
## Summary

- 修复 Material instant navigation 移除 Hypothesis 动态高亮样式资源后未恢复的问题
- 在导航后恢复 Hypothesis 注入的非脚本资源，确保正文高亮继续渲染
- 更新本地控制脚本缓存版本并补充回归测试

## Validation

- `uv run python -m unittest discover -s test`
- `uv run mkdocs build -q`
- `node --check docs/_static/js/hypothesis.js`
- `git diff --check`
- `python3 scripts/check-characters.py`
- `bash scripts/check-upstream-remnants.sh`