### PR TITLE
fix: register intro product-manager-types stub in nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
     - F.A.Q.: intro/faq.md
     - 产品经理黑话速查: intro/glossary.md
     - 自学路线: intro/self-study-roadmap.md
+    - 产品经理岗位类别: intro/product-manager-types.md
   - 产品方法论:
     - 产品方法论简介: pm/index.md
     - 思维模型:


### PR DESCRIPTION
## Summary

- 岗位类别拆分后，简介里的兼容页 `intro/product-manager-types.md` 仍保留，但未登记 `nav`
- CI `check-nav.py` 将其判为孤儿页，Build 失败、gh-pages 部署被跳过
- 把该页重新登记到简介导航

## Test plan

- [x] `uv run python scripts/check-nav.py`
- [x] `git diff --check`


Made with [Cursor](https://cursor.com)