### PR TITLE
test: 用全站站内链接检查替换单页标题锚点断言

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,8 @@ jobs:
         run: uv sync --frozen
       - name: Check nav vs docs consistency
         run: uv run python scripts/check-nav.py
+      - name: Check in-repo Markdown links
+        run: uv run python scripts/check-doc-links.py
       - name: Cache Node.js dependencies
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5
         id: cache-node

--- a/.github/workflows/check-scripts.yml
+++ b/.github/workflows/check-scripts.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - scripts/**
       - hooks/**
+      - test/**
       - .remarkrc
       - package.json
       - yarn.lock
@@ -55,7 +56,7 @@ jobs:
       - name: Install Python dependencies
         run: uv sync --group dev
       - name: Check Python Syntax
-        run: python -m py_compile hooks/*.py scripts/check-characters.py
+        run: python -m py_compile hooks/*.py scripts/check-characters.py scripts/doc_links.py
       - name: Run All Python Unit Tests
         run: |
           uv run python3 -m unittest

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ uv run mkdocs --help
 -   `git diff --check`：空白错误检查
 -   `uv run mkdocs build -q`：站点构建
 -   `python3 scripts/check-characters.py`：字符规范检查
+-   `uv run python scripts/check-doc-links.py`：站内 Markdown/HTML 链接与标题锚点
 -   `bash scripts/check-upstream-remnants.sh`：上游残留检查
 
 * * *

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -22,5 +22,7 @@
 
 - `check-characters.py` 扫描 Markdown 文件中的异常非可见字符，以及可替换为对应 CJK 字符的部首
   （和笔画字符）；字符数据见同目录 `char-map.json`。为仓库门禁之一。
+- `check-doc-links.py` 扫描 `docs/**/*.md` 的站内 Markdown/HTML 链接与标题锚点（外链跳过，
+  与 CI htmltest 的 `skip_external` 一致）。实现见 `doc_links.py`。为仓库门禁之一。
 - `gen-favicon.py` 生成站点 favicon（用法见文件头部注释）
 - `utils/find_jk.py` 遗留小工具：查找源文件中非中文码位的汉字字符

--- a/scripts/check-doc-links.py
+++ b/scripts/check-doc-links.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+"""CLI wrapper: uv run python scripts/check-doc-links.py"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from scripts.doc_links import main
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/doc_links.py
+++ b/scripts/doc_links.py
@@ -1,0 +1,157 @@
+"""Scan docs/*.md for in-repo Markdown/HTML links and heading anchors.
+
+External http(s)/mailto/tel links are skipped (same policy as CI htmltest).
+Heading ids use MkDocs' slugify (pymdownx.slugs.slugify case=lower) plus
+Python-Markdown toc uniqueness (`_1`, `_2`, …).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote, urlparse
+
+from markdown.extensions.toc import unique
+from pymdownx.slugs import slugify
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_DIR = REPO_ROOT / "docs"
+
+_slugify = slugify(case="lower")
+
+SKIP_SCHEMES = frozenset({"http", "https", "mailto", "tel", "data", "javascript"})
+FENCE_RE = re.compile(r"^```.*?^```", re.MULTILINE | re.DOTALL)
+INLINE_CODE_RE = re.compile(r"`[^`]+`")
+MD_LINK_RE = re.compile(
+    r"!?\[[^\]]*\]\(\s*<?([^)\s>]+)>?(?:\s+(?:\"[^\"]*\"|'[^']*'))?\s*\)"
+)
+HTML_REF_RE = re.compile(r"""(?:href|src)\s*=\s*['"]([^'"]+)['"]""", re.IGNORECASE)
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$", re.MULTILINE)
+HEADING_INLINE_LINK_RE = re.compile(r"\[([^\]]+)\]\([^)]+\)")
+HEADING_CODE_RE = re.compile(r"`([^`]+)`")
+
+
+def _visible_markdown(text: str) -> str:
+    """Drop fenced and inline code so example links/headings are not checked."""
+    return INLINE_CODE_RE.sub(" ", FENCE_RE.sub(" ", text))
+
+
+def heading_slugs(text: str) -> set[str]:
+    ids: set[str] = set()
+    for match in HEADING_RE.finditer(_visible_markdown(text)):
+        title = match.group(2).strip()
+        title = re.sub(r"\s+#+\s*$", "", title)
+        title = HEADING_INLINE_LINK_RE.sub(r"\1", title)
+        title = HEADING_CODE_RE.sub(r"\1", title)
+        unique(_slugify(title, "-"), ids)
+    return ids
+
+
+def extract_hrefs(text: str) -> list[str]:
+    visible = _visible_markdown(text)
+    found = [match.group(1).strip() for match in MD_LINK_RE.finditer(visible)]
+    found.extend(match.group(1).strip() for match in HTML_REF_RE.finditer(visible))
+    return found
+
+
+def _is_external(href: str) -> bool:
+    parsed = urlparse(href)
+    if parsed.scheme.lower() in SKIP_SCHEMES:
+        return True
+    return href.startswith("//")
+
+
+def resolve_target(source: Path, href: str) -> Path | None:
+    """Return the docs path a local href should open, or None if unresolvable."""
+    parsed = urlparse(href)
+    raw_path = unquote(parsed.path)
+
+    if raw_path.startswith("/"):
+        candidate = DOCS_DIR / raw_path.lstrip("/")
+    elif raw_path == "":
+        candidate = source
+    else:
+        candidate = source.parent / raw_path
+
+    try:
+        docs_root = DOCS_DIR.resolve()
+        candidate = candidate.resolve()
+        candidate.relative_to(docs_root)
+    except (OSError, ValueError):
+        return None
+
+    if candidate.is_file():
+        return candidate
+    if candidate.is_dir():
+        index = candidate / "index.md"
+        return index if index.is_file() else None
+    if candidate.suffix:
+        return None
+    md = candidate.with_suffix(".md")
+    if md.is_file():
+        return md
+    index = candidate / "index.md"
+    if index.is_file():
+        return index
+    return None
+
+
+def check_href(source: Path, href: str, slug_cache: dict[Path, set[str]]) -> str | None:
+    """Return an error message, or None if the href is fine / out of scope."""
+    if not href or href == "#":
+        return None
+    if _is_external(href):
+        return None
+
+    fragment = unquote(urlparse(href).fragment)
+    target = resolve_target(source, href)
+    if target is None:
+        rel = source.relative_to(REPO_ROOT)
+        return f"{rel}: missing target {href}"
+
+    if not fragment:
+        return None
+    slugs = slug_cache.setdefault(
+        target, heading_slugs(target.read_text(encoding="utf-8"))
+    )
+    if fragment not in slugs:
+        rel = source.relative_to(REPO_ROOT)
+        dest = target.relative_to(REPO_ROOT)
+        return f"{rel}: missing heading #{fragment} in {dest}"
+    return None
+
+
+def iter_markdown_files() -> list[Path]:
+    return sorted(DOCS_DIR.rglob("*.md"))
+
+
+def collect_problems() -> list[str]:
+    slug_cache: dict[Path, set[str]] = {}
+    problems: list[str] = []
+    seen: set[tuple[Path, str]] = set()
+    for path in iter_markdown_files():
+        for href in extract_hrefs(path.read_text(encoding="utf-8")):
+            key = (path, href)
+            if key in seen:
+                continue
+            seen.add(key)
+            error = check_href(path, href, slug_cache)
+            if error:
+                problems.append(error)
+    return problems
+
+
+def main() -> int:
+    problems = collect_problems()
+    if problems:
+        print(f"check-doc-links: FAILED ({len(problems)} 处)")
+        for item in problems:
+            print(f"FAIL: {item}")
+        return 1
+    print(f"check-doc-links: OK ({len(iter_markdown_files())} pages)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/test_doc_links.py
+++ b/test/test_doc_links.py
@@ -1,40 +1,69 @@
-"""Guard against the broken documentation links reported by MkDocs."""
+"""Site-wide in-repo Markdown/HTML link and heading-anchor checks."""
 
 from __future__ import annotations
 
 import unittest
 from pathlib import Path
 
+from scripts.doc_links import (
+    DOCS_DIR,
+    check_href,
+    collect_problems,
+    extract_hrefs,
+    heading_slugs,
+    resolve_target,
+)
 
-ROOT = Path(__file__).resolve().parents[1]
-HOME = ROOT / "docs" / "index.md"
-CAPABILITY = ROOT / "docs" / "intro" / "capability.md"
-PROJECT_MANAGEMENT = ROOT / "docs" / "pm" / "project-management.md"
 
+class TestExtractAndResolve(unittest.TestCase):
+    def test_extracts_markdown_and_html_hrefs(self):
+        text = (
+            "see [a](foo.md#bar) and <a href=\"pm/\">card</a>\n"
+            "http is [ext](https://example.com/x.md)\n"
+        )
+        hrefs = extract_hrefs(text)
+        self.assertIn("foo.md#bar", hrefs)
+        self.assertIn("pm/", hrefs)
+        self.assertIn("https://example.com/x.md", hrefs)
 
-class TestDocumentationLinks(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.home = HOME.read_text(encoding="utf-8")
-        cls.capability = CAPABILITY.read_text(encoding="utf-8")
-        cls.project_management = PROJECT_MANAGEMENT.read_text(encoding="utf-8")
+    def test_ignores_links_inside_fenced_code(self):
+        text = "```\n[broken](does-not-exist.md)\n```\n[ok](index.md)\n"
+        self.assertEqual(extract_hrefs(text), ["index.md"])
 
-    def test_homepage_section_links_target_documented_index_pages(self):
-        for section in ("pm", "ai", "practice", "tech", "job"):
-            with self.subTest(section=section):
-                self.assertIn(f"]({section}/index.md)", self.home)
-                self.assertNotIn(f"]({section}/)", self.home)
+    def test_directory_url_resolves_to_index(self):
+        home = DOCS_DIR / "index.md"
+        self.assertEqual(resolve_target(home, "pm/"), DOCS_DIR / "pm" / "index.md")
+        self.assertEqual(
+            resolve_target(home, "intro/about/"), DOCS_DIR / "intro" / "about.md"
+        )
 
-    def test_project_management_links_to_existing_capability_heading(self):
-        self.assertIn("### ② AI 系统与工程理解", self.capability)
+    def test_capability_heading_slug_matches_mkdocs(self):
+        slugs = heading_slugs((DOCS_DIR / "intro" / "capability.md").read_text())
+        self.assertIn("②-ai-系统与工程理解", slugs)
+        self.assertNotIn("软件工程素养", slugs)
+
+    def test_missing_file_and_missing_heading_are_errors(self):
+        source = DOCS_DIR / "pm" / "project-management.md"
+        cache: dict[Path, set[str]] = {}
+        self.assertIsNone(
+            check_href(
+                source, "../intro/capability.md#②-ai-系统与工程理解", cache
+            )
+        )
         self.assertIn(
-            "../intro/capability.md#②-ai-系统与工程理解",
-            self.project_management,
+            "missing target",
+            check_href(source, "../intro/nope.md", cache) or "",
         )
-        self.assertNotIn(
-            "../intro/capability.md#软件工程素养",
-            self.project_management,
+        self.assertIn(
+            "missing heading",
+            check_href(source, "../intro/capability.md#软件工程素养", cache) or "",
         )
+
+
+class TestSiteWideDocLinks(unittest.TestCase):
+    def test_all_in_repo_links_resolve(self):
+        problems = collect_problems()
+        self.assertEqual(problems, [], "\n".join(problems))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- 删掉只盯项目管理页一条标题锚点的字符串测试
- 新增 `scripts/check-doc-links.py`：扫描全部 `docs/**/*.md` 的站内 Markdown/HTML 链接和标题锚点（外链跳过，与 htmltest `skip_external` 一致）
- Build 在 mkdocs 之前跑一遍；`unittest` 覆盖全站扫描和解析用例

## Test plan
- [x] `uv run python scripts/check-doc-links.py` → OK (600 pages)
- [x] `uv run python3 -m unittest` → 48 passed


Made with [Cursor](https://cursor.com)